### PR TITLE
BAH-4362 | Add. fontawesome-css library to render styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "style-loader": "^3.3.3",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^4.15.1"
+    "webpack-dev-server": "^4.15.1",
+    "@fortawesome/fontawesome-free": "^7.1.0"
   },
   "dependencies": {
     "ajv": "^8.17.1",

--- a/src/components/ObsControl.jsx
+++ b/src/components/ObsControl.jsx
@@ -186,7 +186,7 @@ export class ObsControl extends addMoreDecorator(Component) {
     const { metadata: { properties }, value } = this.props;
     const isAbnormal = find(properties, (val, key) => (key === 'abnormal' && val));
     const isAbnormalObs = (value.interpretation === 'ABNORMAL');
-    const abnormalClassName = classNames({ 'fa fa-ok': isAbnormalObs });
+    const abnormalClassName = classNames({ 'fas fa-check': isAbnormalObs });
     if (isAbnormal) {
       return (
         <button className="abnormal-button" disabled={!value.value} onClick={this.setAbnormal} >

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,3 +1,9 @@
+import '@fortawesome/fontawesome-free/css/fontawesome.css';
+import '@fortawesome/fontawesome-free/css/solid.css';
+import '@fortawesome/fontawesome-free/css/regular.css';
+import '@fortawesome/fontawesome-free/css/brands.css';
+import '@fortawesome/fontawesome-free/css/v4-shims.css';
+
 export { Container } from 'components/Container.jsx';
 export { ObsControl } from 'components/ObsControl.jsx';
 export { Label } from 'components/Label.jsx';
@@ -61,4 +67,3 @@ export { CodedMultiSelectValueMapper } from 'src/mapper/CodedMultiSelectValueMap
 export { TranslationKeyGenerator } from 'src/services/TranslationKeyService';
 
 import '../styles/styles.scss';
-

--- a/styles/common/_grid.scss
+++ b/styles/common/_grid.scss
@@ -14,6 +14,9 @@
     overflow: hidden;
     text-overflow: ellipsis;
     height: 32px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    cursor: pointer;
     i.fa-ok {
       display: none;
       padding-top: 0;
@@ -26,9 +29,6 @@
       padding-left: 3px;
       background: #d8d8d8;
       border-color: #d0d0d0;
-      i.fa-ok {
-        display: inline-block;
-      }
     }
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,6 +39,20 @@ module.exports = {
         include: path.join(__dirname, 'src')
       },
       {
+        test: /\.css$/,
+        include: /node_modules\/@fortawesome/,
+        use: [
+          'style-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              url: true,
+              import: true
+            }
+          }
+        ]
+      },
+      {
         test: /\.scss$/,
         use: [
           MiniCssExtractPlugin.loader,
@@ -48,6 +62,10 @@ module.exports = {
       },
       {
         test: /\.(jpe?g|png|gif|svg)$/i,
+        type: 'asset/inline'
+      },
+      {
+        test: /\.(woff|woff2|eot|ttf|otf)$/i,
         type: 'asset/inline'
       }
     ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1159,6 +1159,11 @@
   resolved "https://registry.yarnpkg.com/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz#2dc8c57044de0340eb53a7ba602e59abf80dc799"
   integrity sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ==
 
+"@fortawesome/fontawesome-free@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.1.0.tgz#8eb76278515341720aa74485266f8be121089529"
+  integrity sha512-+WxNld5ZCJHvPQCr/GnzCTVREyStrAJjisUPtUxG5ngDA8TMlPnKp6dddlTpai4+1GNmltAeuk1hJEkBohwZYA==
+
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.13.0.tgz#fb907624df3256d04b9aa2df50d7aa97ec648748"


### PR DESCRIPTION
# Pull Request Summary: BAH-4362

## Overview
This PR adds the Font Awesome CSS library to properly render icon styling in the form2-controls library.

## Ticket Reference
**JIRA:** [BAH-4362](https://bahmni.atlassian.net/jira/software/c/projects/BAH/boards/45?selectedIssue=BAH-4362)

## Summary
Integration of Font Awesome library to replace missing icon styles and modernize icon rendering in the application.


## Dependencies
- **Added:** `@fortawesome/fontawesome-free@^7.1.0` as a dev dependency
