### PR TITLE
BAH-4832 | Transformation of Observation Form data from/ to FHIR format to be taken care in form2-controls library (refactor)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -317,3 +317,84 @@ export class ControlRecordTreeBuilder {
   parseObs(obs: any): any;
   build(metadata: FormMetadata, observation: ObservationData[]): any;
 }
+
+// ==================== FHIR Transformation ====================
+
+/**
+ * FHIR Reference type
+ */
+export interface FhirReference {
+  reference: string;
+  type?: string;
+  display?: string;
+}
+
+/**
+ * Options for FHIR observation transformation
+ */
+export interface FhirTransformOptions {
+  /** FHIR Reference to the patient (e.g., { reference: 'Patient/uuid' }) */
+  patientReference: FhirReference;
+  /** FHIR Reference to the encounter (e.g., { reference: 'Encounter/uuid' }) */
+  encounterReference: FhirReference;
+  /** FHIR Reference to the performer/practitioner (e.g., { reference: 'Practitioner/uuid' }) */
+  performerReference: FhirReference;
+}
+
+/**
+ * FHIR Observation bundle entry
+ */
+export interface FhirObservationEntry {
+  /** The FHIR Observation resource */
+  resource: {
+    resourceType: 'Observation';
+    id: string;
+    status: string;
+    code: any;
+    subject: FhirReference;
+    encounter: FhirReference;
+    performer: FhirReference[];
+    effectiveDateTime: string;
+    valueQuantity?: { value: number };
+    valueString?: string;
+    valueBoolean?: boolean;
+    valueDateTime?: string;
+    valueCodeableConcept?: any;
+    interpretation?: any[];
+    extension?: any[];
+    note?: any[];
+    hasMember?: FhirReference[];
+    [key: string]: any;
+  };
+  /** The full URL for bundle reference (e.g., 'urn:uuid:xxx') */
+  fullUrl: string;
+}
+
+/**
+ * Transforms Container observations to FHIR Observation resources
+ */
+export class FhirObservationTransformer {
+  /**
+   * Transform observations to FHIR Observation resources
+   * @param observations - Raw observations from Container.getValue() or Form2Observation[]
+   * @param options - Configuration options with patient, encounter, and performer references
+   * @returns Array of FHIR Observation bundle entries with resource and fullUrl
+   */
+  toFhir(
+    observations: ObservationData[],
+    options: FhirTransformOptions
+  ): FhirObservationEntry[];
+}
+
+// ==================== FHIR Constants ====================
+
+export const FHIR_OBSERVATION_INTERPRETATION_SYSTEM: string;
+export const FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL: string;
+export const FHIR_OBSERVATION_COMPLEX_DATA_URL: string;
+export const CONCEPT_DATATYPE_NUMERIC: string;
+export const CONCEPT_DATATYPE_COMPLEX: string;
+export const FHIR_OBSERVATION_STATUS_FINAL: string;
+export const FHIR_RESOURCE_TYPE_OBSERVATION: string;
+export const DATE_REGEX_PATTERN: RegExp;
+export const DATETIME_REGEX_PATTERN: RegExp;
+export const INTERPRETATION_TO_CODE: Record<string, { code: string; display: string }>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -372,19 +372,16 @@ export interface FhirObservationEntry {
 
 /**
  * Transforms Container observations to FHIR Observation resources
+ * @param observations - Raw observations from Container.getValue() or Form2Observation[]
+ * @param options - Configuration options with patient, encounter, and performer references
+ * @returns Array of FHIR Observation bundle entries with resource and fullUrl
  */
-export class FhirObservationTransformer {
-  /**
-   * Transform observations to FHIR Observation resources
-   * @param observations - Raw observations from Container.getValue() or Form2Observation[]
-   * @param options - Configuration options with patient, encounter, and performer references
-   * @returns Array of FHIR Observation bundle entries with resource and fullUrl
-   */
-  toFhir(
-    observations: ObservationData[],
-    options: FhirTransformOptions
-  ): FhirObservationEntry[];
-}
+export function transformToFhir(
+  observations: ObservationData[],
+  options: FhirTransformOptions
+): FhirObservationEntry[];
+
+export const FhirObservationTransformer
 
 // ==================== FHIR Constants ====================
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -376,7 +376,7 @@ export interface FhirObservationEntry {
  * @param options - Configuration options with patient, encounter, and performer references
  * @returns Array of FHIR Observation bundle entries with resource and fullUrl
  */
-export function getFhirObeservations(
+export function getFhirObservations(
   observations: ObservationData[],
   options: FhirTransformOptions
 ): FhirObservationEntry[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -376,7 +376,7 @@ export interface FhirObservationEntry {
  * @param options - Configuration options with patient, encounter, and performer references
  * @returns Array of FHIR Observation bundle entries with resource and fullUrl
  */
-export function transformToFhir(
+export function getFhirObeservations(
   observations: ObservationData[],
   options: FhirTransformOptions
 ): FhirObservationEntry[];

--- a/package.json
+++ b/package.json
@@ -1,18 +1,11 @@
 {
   "name": "@bahmni/form2-controls",
-  "version": "0.0.06",
+  "version": "0.0.7",
   "description": "Repository for form controls",
   "license": "MPL-2.0",
   "main": "./dist/bundle.js",
   "style": "./dist/bundle.css",
   "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "default": "./dist/bundle.js"
-    },
-    "./dist/bundle.css": "./dist/bundle.css"
-  },
   "scripts": {
     "clean": "rimraf dist/*",
     "build": "webpack && copyfiles index.d.ts dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bahmni/form2-controls",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Repository for form controls",
   "license": "MPL-2.0",
   "main": "./dist/bundle.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bahmni/form2-controls",
-  "version": "0.0.11",
+  "version": "0.0.3",
   "description": "Repository for form controls",
   "license": "MPL-2.0",
   "main": "./dist/bundle.js",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,18 @@
 {
   "name": "@bahmni/form2-controls",
-  "version": "0.0.3",
+  "version": "0.0.06",
   "description": "Repository for form controls",
   "license": "MPL-2.0",
   "main": "./dist/bundle.js",
   "style": "./dist/bundle.css",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/bundle.js"
+    },
+    "./dist/bundle.css": "./dist/bundle.css"
+  },
   "scripts": {
     "clean": "rimraf dist/*",
     "build": "webpack && copyfiles index.d.ts dist",
@@ -37,6 +44,7 @@
     "@babel/eslint-parser": "^7.28.4",
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.27.1",
+    "@fortawesome/fontawesome-free": "^7.1.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
@@ -67,8 +75,7 @@
     "style-loader": "^3.3.3",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^4.15.1",
-    "@fortawesome/fontawesome-free": "^7.1.0"
+    "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {
     "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@babel/eslint-parser": "^7.28.4",
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.27.1",
-    "@fortawesome/fontawesome-free": "^7.1.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
@@ -68,6 +67,7 @@
     "style-loader": "^3.3.3",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4",
+    "@fortawesome/fontawesome-free": "^7.1.0",
     "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bahmni/form2-controls",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Repository for form controls",
   "license": "MPL-2.0",
   "main": "./dist/bundle.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bahmni/form2-controls",
-  "version": "0.0.7",
+  "version": "0.0.11",
   "description": "Repository for form controls",
   "license": "MPL-2.0",
   "main": "./dist/bundle.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bahmni/form2-controls",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Repository for form controls",
   "license": "MPL-2.0",
   "main": "./dist/bundle.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bahmni/form2-controls",
-  "version": "0.0.3",
+  "version": "0.0.11",
   "description": "Repository for form controls",
   "license": "MPL-2.0",
   "main": "./dist/bundle.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bahmni/form2-controls",
-  "version": "0.0.7",
+  "version": "0.0.12",
   "description": "Repository for form controls",
   "license": "MPL-2.0",
   "main": "./dist/bundle.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bahmni/form2-controls",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Repository for form controls",
   "license": "MPL-2.0",
   "main": "./dist/bundle.js",
@@ -37,6 +37,7 @@
     "@babel/eslint-parser": "^7.28.4",
     "@babel/preset-env": "^7.28.3",
     "@babel/preset-react": "^7.27.1",
+    "@fortawesome/fontawesome-free": "^7.1.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
@@ -67,7 +68,6 @@
     "style-loader": "^3.3.3",
     "webpack": "^5.89.0",
     "webpack-cli": "^5.1.4",
-    "@fortawesome/fontawesome-free": "^7.1.0",
     "webpack-dev-server": "^4.15.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bahmni/form2-controls",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Repository for form controls",
   "license": "MPL-2.0",
   "main": "./dist/bundle.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bahmni/form2-controls",
-  "version": "0.0.12",
+  "version": "0.0.3",
   "description": "Repository for form controls",
   "license": "MPL-2.0",
   "main": "./dist/bundle.js",

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,3 +1,8 @@
+export const NUMBER = 'number';
+export const STRING = 'string';
+export const BOOLEAN = 'boolean';
+export const OBJECT = 'object';
+
 const Constants = {
   Grid: {
     defaultRowWidth: 1,
@@ -17,10 +22,10 @@ const Constants = {
     error: 'error',
   },
   bahmni: 'Bahmni',
-   NUMBER: 'number',
-   STRING: 'string',
-   BOOLEAN: 'boolean',
-   OBJECT: 'object',
+  NUMBER,
+  STRING,
+  BOOLEAN,
+  OBJECT,
 
   messageType: {
     success: 'success',

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,6 +17,10 @@ const Constants = {
     error: 'error',
   },
   bahmni: 'Bahmni',
+   NUMBER: 'number',
+   STRING: 'string',
+   BOOLEAN: 'boolean',
+   OBJECT: 'object',
 
   messageType: {
     success: 'success',

--- a/src/constants/fhir.js
+++ b/src/constants/fhir.js
@@ -1,0 +1,26 @@
+/**
+ * FHIR-related constants for observation transformation
+ */
+
+export const FHIR_OBSERVATION_INTERPRETATION_SYSTEM =
+  'http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation';
+
+export const FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL =
+  'http://fhir.bahmni.org/ext/observation/form-namespace-path';
+
+export const FHIR_OBSERVATION_COMPLEX_DATA_URL =
+  'http://fhir.bahmni.org/ext/observation/complex-data';
+
+export const CONCEPT_DATATYPE_NUMERIC = 'Numeric';
+export const CONCEPT_DATATYPE_COMPLEX = 'Complex';
+
+export const FHIR_OBSERVATION_STATUS_FINAL = 'final';
+export const FHIR_RESOURCE_TYPE_OBSERVATION = 'Observation';
+
+export const DATE_REGEX_PATTERN = /^\d{4}-\d{2}-\d{2}/;
+export const DATETIME_REGEX_PATTERN = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+
+export const INTERPRETATION_TO_CODE = {
+  ABNORMAL: { code: 'A', display: 'Abnormal' },
+  NORMAL: { code: 'N', display: 'Normal' },
+};

--- a/src/helpers/FhirObservationTransformer.js
+++ b/src/helpers/FhirObservationTransformer.js
@@ -44,20 +44,11 @@ const generateUUID = () => {
   if (typeof crypto !== 'undefined' && crypto.randomUUID) {
     return crypto.randomUUID();
   }
-  // Fallback for environments without crypto.randomUUID
-  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
-    const bytes = new Uint8Array(16);
-    crypto.getRandomValues(bytes);
-    bytes[6] = (bytes[6] & 0x0f) | 0x40;
-    bytes[8] = (bytes[8] & 0x3f) | 0x80;
-    const hex = [...bytes].map((b) => b.toString(16).padStart(2, '0')).join('');
-    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
-  }
-  // Final fallback using Math.random
+
   console.warn(
     'FhirObservationTransformer: Using Math.random() for UUID generation. ' +
     'This is not cryptographically secure and should not be used for healthcare data in production. ' +
-    'Please ensure crypto.randomUUID() or crypto.getRandomValues() is available.'
+    'Please ensure crypto.randomUUID() is available.'
   );
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
     const r = (Math.random() * 16) | 0;

--- a/src/helpers/FhirObservationTransformer.js
+++ b/src/helpers/FhirObservationTransformer.js
@@ -213,7 +213,7 @@ const createObservationResource = (observationPayload, options) => {
  * @param {Object} options.performerReference - FHIR Reference to performer (e.g., { reference: 'Practitioner/uuid' })
  * @returns {Array<{resource: Object, fullUrl: string}>} Array of FHIR Observation bundle entries
  */
-export function transformToFhir(observations, options) {
+export function getFhirObeservations(observations, options) {
   
   if (!options || !options.patientReference || !options.encounterReference || !options.performerReference) {
   throw new Error('transformToFhir requires patientReference, encounterReference, and performerReference in options');
@@ -233,7 +233,7 @@ export function transformToFhir(observations, options) {
 
     if (obs.groupMembers && obs.groupMembers.length > 0) {
       // Recursively process group members
-      const memberResults = transformToFhir(obs.groupMembers, options);
+      const memberResults = getFhirObeservations(obs.groupMembers, options);
       results.push(...memberResults);
 
       // Create parent observation with hasMember references
@@ -271,4 +271,4 @@ export function transformToFhir(observations, options) {
   return results;
 }
 
-export default transformToFhir;
+export default getFhirObeservations;

--- a/src/helpers/FhirObservationTransformer.js
+++ b/src/helpers/FhirObservationTransformer.js
@@ -9,12 +9,7 @@ import {
   DATE_REGEX_PATTERN,
   INTERPRETATION_TO_CODE,
 } from 'src/constants/fhir';
-import{
-   NUMBER,
-   STRING,
-   BOOLEAN,
-   OBJECT
-} from 'src/constants';
+import { NUMBER, STRING, BOOLEAN, OBJECT } from 'src/constants';
 
 const createCoding = (code, systemURL, display) => {
   const coding = { code };

--- a/src/helpers/FhirObservationTransformer.js
+++ b/src/helpers/FhirObservationTransformer.js
@@ -213,7 +213,7 @@ const createObservationResource = (observationPayload, options) => {
  * @param {Object} options.performerReference - FHIR Reference to performer (e.g., { reference: 'Practitioner/uuid' })
  * @returns {Array<{resource: Object, fullUrl: string}>} Array of FHIR Observation bundle entries
  */
-export function getFhirObeservations(observations, options) {
+export function getFhirObservations(observations, options) {
   
   if (!options || !options.patientReference || !options.encounterReference || !options.performerReference) {
   throw new Error('transformToFhir requires patientReference, encounterReference, and performerReference in options');
@@ -233,7 +233,7 @@ export function getFhirObeservations(observations, options) {
 
     if (obs.groupMembers && obs.groupMembers.length > 0) {
       // Recursively process group members
-      const memberResults = getFhirObeservations(obs.groupMembers, options);
+      const memberResults = getFhirObservations(obs.groupMembers, options);
       results.push(...memberResults);
 
       // Create parent observation with hasMember references
@@ -271,4 +271,4 @@ export function getFhirObeservations(observations, options) {
   return results;
 }
 
-export default getFhirObeservations;
+export default getFhirObservations;

--- a/src/helpers/FhirObservationTransformer.js
+++ b/src/helpers/FhirObservationTransformer.js
@@ -1,0 +1,272 @@
+import {
+  FHIR_OBSERVATION_INTERPRETATION_SYSTEM,
+  FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL,
+  FHIR_OBSERVATION_COMPLEX_DATA_URL,
+  CONCEPT_DATATYPE_NUMERIC,
+  CONCEPT_DATATYPE_COMPLEX,
+  FHIR_OBSERVATION_STATUS_FINAL,
+  FHIR_RESOURCE_TYPE_OBSERVATION,
+  DATE_REGEX_PATTERN,
+  INTERPRETATION_TO_CODE,
+} from 'src/constants/fhir';
+
+/**
+ * Creates a FHIR Coding object
+ * @param {string} code - The code value
+ * @param {string} [systemURL] - The coding system URL
+ * @param {string} [display] - Display text for the coding
+ * @returns {Object} FHIR Coding object
+ */
+const createCoding = (code, systemURL, display) => {
+  const coding = { code };
+  if (systemURL) {
+    coding.system = systemURL;
+  }
+  if (display) {
+    coding.display = display;
+  }
+  return coding;
+};
+
+/**
+ * Creates a FHIR CodeableConcept object
+ * @param {Array} coding - Array of Coding objects
+ * @param {string} [displayText] - Display text for the concept
+ * @returns {Object} FHIR CodeableConcept object
+ */
+const createCodeableConcept = (coding, displayText) => {
+  const concept = { coding };
+  if (displayText) {
+    concept.text = displayText;
+  }
+  return concept;
+};
+
+/**
+ * Generates a UUID v4
+ * @returns {string} UUID string
+ */
+const generateUUID = () => {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  // Fallback for environments without crypto.randomUUID
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+};
+
+/**
+ * Handles string value conversion for FHIR observation
+ * @param {string} value - The string value
+ * @param {Object} observation - The FHIR observation being built
+ * @param {string} [conceptDatatype] - The concept datatype
+ */
+const handleStringValue = (value, observation, conceptDatatype) => {
+  const trimmedValue = value.trim();
+
+  if (trimmedValue === '') {
+    return;
+  }
+
+  if (DATE_REGEX_PATTERN.test(trimmedValue)) {
+    const dateValue = new Date(trimmedValue);
+    if (!isNaN(dateValue.getTime())) {
+      observation.valueDateTime = dateValue.toISOString();
+      return;
+    }
+  }
+
+  if (conceptDatatype === CONCEPT_DATATYPE_NUMERIC) {
+    const numericValue = parseFloat(trimmedValue);
+    if (!isNaN(numericValue)) {
+      observation.valueQuantity = { value: numericValue };
+      return;
+    }
+  }
+
+  observation.valueString = value;
+};
+
+/**
+ * Creates a single FHIR Observation resource from a form2 observation
+ * @param {Object} observationPayload - The form2 observation data
+ * @param {Object} options - Configuration options
+ * @param {Object} options.patientReference - FHIR Reference to patient
+ * @param {Object} options.encounterReference - FHIR Reference to encounter
+ * @param {Object} options.performerReference - FHIR Reference to performer
+ * @returns {Object} FHIR Observation resource
+ */
+const createObservationResource = (observationPayload, options) => {
+  const { patientReference, encounterReference, performerReference } = options;
+
+  const conceptUuid =
+    typeof observationPayload.concept === 'object'
+      ? observationPayload.concept.uuid
+      : observationPayload.concept;
+
+  const observation = {
+    resourceType: FHIR_RESOURCE_TYPE_OBSERVATION,
+    status: FHIR_OBSERVATION_STATUS_FINAL,
+    code: createCodeableConcept([createCoding(conceptUuid)]),
+    subject: patientReference,
+    encounter: encounterReference,
+    performer: [performerReference],
+    effectiveDateTime:
+      observationPayload.obsDatetime ||
+      observationPayload.observationDateTime ||
+      new Date().toISOString(),
+  };
+
+  const value = observationPayload.value;
+  const conceptDatatype =
+    typeof observationPayload.concept === 'object'
+      ? observationPayload.concept.datatype
+      : undefined;
+
+  if (value !== null && value !== undefined) {
+    switch (typeof value) {
+      case 'number':
+        observation.valueQuantity = { value };
+        break;
+      case 'string': {
+        if (conceptDatatype === CONCEPT_DATATYPE_COMPLEX && value.trim() !== '') {
+          observation.extension = observation.extension || [];
+          observation.extension.push({
+            url: FHIR_OBSERVATION_COMPLEX_DATA_URL,
+            valueAttachment: { url: value },
+          });
+          observation.valueString = value;
+        } else {
+          handleStringValue(value, observation, conceptDatatype);
+        }
+        break;
+      }
+      case 'boolean':
+        observation.valueBoolean = value;
+        break;
+      case 'object':
+        if (value instanceof Date) {
+          observation.valueDateTime = value.toISOString();
+        } else if (value && 'uuid' in value) {
+          observation.valueCodeableConcept = createCodeableConcept([
+            createCoding(value.uuid, undefined, value.display || value.displayString),
+          ]);
+        }
+        break;
+    }
+  }
+
+  if (observationPayload.interpretation) {
+    const interpretationValue = observationPayload.interpretation.toUpperCase();
+    const mapping =
+      INTERPRETATION_TO_CODE[interpretationValue] || INTERPRETATION_TO_CODE.NORMAL;
+
+    observation.interpretation = [
+      {
+        coding: [
+          {
+            system: FHIR_OBSERVATION_INTERPRETATION_SYSTEM,
+            code: mapping.code,
+            display: mapping.display,
+          },
+        ],
+      },
+    ];
+  }
+
+  if (observationPayload.formNamespace && observationPayload.formFieldPath) {
+    observation.extension = observation.extension || [];
+    observation.extension.push({
+      url: FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL,
+      valueString: `${observationPayload.formNamespace}^${observationPayload.formFieldPath}`,
+    });
+  }
+
+  if (observationPayload.comment) {
+    observation.note = [
+      {
+        text: observationPayload.comment,
+      },
+    ];
+  }
+
+  return observation;
+};
+
+/**
+ * Transforms Container observations to FHIR Observation resources
+ *
+ * @example
+ * const transformer = new FhirObservationTransformer();
+ * const fhirObservations = transformer.toFhir(observations, {
+ *   patientReference: { reference: 'Patient/uuid' },
+ *   encounterReference: { reference: 'Encounter/uuid' },
+ *   performerReference: { reference: 'Practitioner/uuid' }
+ * });
+ */
+export default class FhirObservationTransformer {
+  /**
+   * Transform Container observations to FHIR Observation resources
+   * @param {Array} observations - Raw observations from Container.getValue() or transformed Form2Observation[]
+   * @param {Object} options - Configuration options
+   * @param {Object} options.patientReference - FHIR Reference to patient (e.g., { reference: 'Patient/uuid' })
+   * @param {Object} options.encounterReference - FHIR Reference to encounter (e.g., { reference: 'Encounter/uuid' })
+   * @param {Object} options.performerReference - FHIR Reference to performer (e.g., { reference: 'Practitioner/uuid' })
+   * @returns {Array<{resource: Object, fullUrl: string}>} Array of FHIR Observation bundle entries
+   */
+  toFhir(observations, options) {
+    if (!observations || !Array.isArray(observations)) {
+      return [];
+    }
+
+    const results = [];
+
+    for (const obs of observations) {
+      // Handle voided observations
+      if (obs.voided) {
+        continue;
+      }
+
+      if (obs.groupMembers && obs.groupMembers.length > 0) {
+        // Recursively process group members
+        const memberResults = this.toFhir(obs.groupMembers, options);
+        results.push(...memberResults);
+
+        // Create parent observation with hasMember references
+        const parentObservation = createObservationResource(obs, options);
+        parentObservation.hasMember = memberResults.map((member) => ({
+          reference: member.fullUrl,
+          type: 'Observation',
+        }));
+
+        const parentUuid = generateUUID();
+        const parentFullUrl = `urn:uuid:${parentUuid}`;
+
+        results.push({
+          resource: {
+            ...parentObservation,
+            id: parentUuid,
+          },
+          fullUrl: parentFullUrl,
+        });
+      } else {
+        const observation = createObservationResource(obs, options);
+        const uuid = generateUUID();
+        const fullUrl = `urn:uuid:${uuid}`;
+
+        results.push({
+          resource: {
+            ...observation,
+            id: uuid,
+          },
+          fullUrl,
+        });
+      }
+    }
+
+    return results;
+  }
+}

--- a/src/helpers/FhirObservationTransformer.js
+++ b/src/helpers/FhirObservationTransformer.js
@@ -45,6 +45,20 @@ const generateUUID = () => {
     return crypto.randomUUID();
   }
   // Fallback for environments without crypto.randomUUID
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = [...bytes].map((b) => b.toString(16).padStart(2, '0')).join('');
+    return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+  }
+  // Final fallback using Math.random
+  console.warn(
+    'FhirObservationTransformer: Using Math.random() for UUID generation. ' +
+    'This is not cryptographically secure and should not be used for healthcare data in production. ' +
+    'Please ensure crypto.randomUUID() or crypto.getRandomValues() is available.'
+  );
   return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
     const r = (Math.random() * 16) | 0;
     const v = c === 'x' ? r : (r & 0x3) | 0x8;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -66,8 +66,8 @@ export { CodedMultiSelectValueMapper } from 'src/mapper/CodedMultiSelectValueMap
 
 // -------------------------- FHIR transformation ---------------------
 export { transformToFhir } from 'src/helpers/FhirObservationTransformer';
-export { default as FhirObservationTransformer } from 'src/helpers/FhirObservationTransformer';
-export * from 'src/constants/fhir';
+import * as FhirConstants from 'src/constants/fhir';
+export { FhirConstants };
 
 // -------------------------- services ---------------------
 export { TranslationKeyGenerator } from 'src/services/TranslationKeyService';

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -65,7 +65,7 @@ export { CodedValueMapper } from 'src/mapper/CodedValueMapper';
 export { CodedMultiSelectValueMapper } from 'src/mapper/CodedMultiSelectValueMapper';
 
 // -------------------------- FHIR transformation ---------------------
-export { getFhirObeservations } from 'src/helpers/FhirObservationTransformer';
+export { getFhirObservations } from 'src/helpers/FhirObservationTransformer';
 import * as FhirConstants from 'src/constants/fhir';
 export { FhirConstants };
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -64,6 +64,10 @@ export { BooleanValueMapper } from 'src/mapper/BooleanValueMapper';
 export { CodedValueMapper } from 'src/mapper/CodedValueMapper';
 export { CodedMultiSelectValueMapper } from 'src/mapper/CodedMultiSelectValueMapper';
 
+// -------------------------- FHIR transformation ---------------------
+export { default as FhirObservationTransformer } from 'src/helpers/FhirObservationTransformer';
+export * from 'src/constants/fhir';
+
 // -------------------------- services ---------------------
 export { TranslationKeyGenerator } from 'src/services/TranslationKeyService';
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -65,7 +65,7 @@ export { CodedValueMapper } from 'src/mapper/CodedValueMapper';
 export { CodedMultiSelectValueMapper } from 'src/mapper/CodedMultiSelectValueMapper';
 
 // -------------------------- FHIR transformation ---------------------
-export { transformToFhir } from 'src/helpers/FhirObservationTransformer';
+export { getFhirObeservations } from 'src/helpers/FhirObservationTransformer';
 import * as FhirConstants from 'src/constants/fhir';
 export { FhirConstants };
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -65,6 +65,7 @@ export { CodedValueMapper } from 'src/mapper/CodedValueMapper';
 export { CodedMultiSelectValueMapper } from 'src/mapper/CodedMultiSelectValueMapper';
 
 // -------------------------- FHIR transformation ---------------------
+export { transformToFhir } from 'src/helpers/FhirObservationTransformer';
 export { default as FhirObservationTransformer } from 'src/helpers/FhirObservationTransformer';
 export * from 'src/constants/fhir';
 

--- a/test/helpers/FhirObservationTransformer.test.js
+++ b/test/helpers/FhirObservationTransformer.test.js
@@ -1,4 +1,4 @@
-import getFhirObeservations
+import getFhirObservations
  from 'src/helpers/FhirObservationTransformer';
 import {
   FHIR_OBSERVATION_INTERPRETATION_SYSTEM,
@@ -17,17 +17,17 @@ describe('FhirObservationTransformer', () => {
 
   describe('toFhir', () => {
     it('should return empty array for null observations', () => {
-      const result = getFhirObeservations(null, defaultOptions);
+      const result = getFhirObservations(null, defaultOptions);
       expect(result).toEqual([]);
     });
 
     it('should return empty array for undefined observations', () => {
-      const result = getFhirObeservations(undefined, defaultOptions);
+      const result = getFhirObservations(undefined, defaultOptions);
       expect(result).toEqual([]);
     });
 
     it('should return empty array for non-array observations', () => {
-      const result = getFhirObeservations('invalid', defaultOptions);
+      const result = getFhirObservations('invalid', defaultOptions);
       expect(result).toEqual([]);
     });
 
@@ -41,7 +41,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.resourceType).toBe(FHIR_RESOURCE_TYPE_OBSERVATION);
@@ -63,7 +63,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueQuantity).toEqual({ value: 72 });
@@ -77,7 +77,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueBoolean).toBe(true);
@@ -91,7 +91,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueDateTime).toBeDefined();
@@ -107,7 +107,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueDateTime).toBe(dateValue.toISOString());
@@ -121,7 +121,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueCodeableConcept).toBeDefined();
@@ -137,7 +137,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueCodeableConcept.coding[0].display).toBe('Female');
@@ -151,7 +151,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueQuantity).toEqual({ value: 75.5 });
@@ -171,7 +171,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.code.coding[0].code).toBe('concept-uuid-2');
@@ -186,7 +186,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.interpretation).toBeDefined();
@@ -206,7 +206,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result[0].resource.interpretation[0].coding[0].code).toBe('N');
       expect(result[0].resource.interpretation[0].coding[0].display).toBe('Normal');
@@ -222,7 +222,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result[0].resource.extension).toBeDefined();
       const formPathExtension = result[0].resource.extension.find(
@@ -241,7 +241,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       const formPathExtension = result[0].resource.extension?.find(
         (ext) => ext.url === FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL
@@ -258,7 +258,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result[0].resource.note).toBeDefined();
       expect(result[0].resource.note[0].text).toBe('This is a clinical note');
@@ -272,7 +272,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result[0].resource.extension).toBeDefined();
       const complexExtension = result[0].resource.extension.find(
@@ -293,7 +293,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result[0].resource.effectiveDateTime).toBe(obsDatetime);
     });
@@ -308,7 +308,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result[0].resource.effectiveDateTime).toBe(observationDateTime);
     });
@@ -321,7 +321,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result[0].resource.code.coding[0].code).toBe('direct-concept-uuid');
     });
@@ -334,7 +334,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result[0].resource.valueString).toBeUndefined();
     });
@@ -358,7 +358,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       // Should have 3 observations: 2 members + 1 parent
       expect(result).toHaveLength(3);
@@ -395,7 +395,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       // Should have 3 observations: 1 leaf + 1 inner parent + 1 outer parent
       expect(result).toHaveLength(3);
@@ -433,7 +433,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       // Should have 2 observations: 1 active member + 1 parent
       expect(result).toHaveLength(2);
@@ -460,7 +460,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result).toHaveLength(3);
       expect(result[0].resource.valueString).toBe('value1');
@@ -475,7 +475,7 @@ describe('FhirObservationTransformer', () => {
         { concept: { uuid: 'c3' }, value: 'v3' },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       const ids = result.map((r) => r.resource.id);
       const uniqueIds = new Set(ids);
@@ -496,7 +496,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueString).toBeUndefined();
@@ -512,14 +512,14 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueString).toBeUndefined();
     });
 
     it('should handle empty observations array', () => {
-      const result = getFhirObeservations([], defaultOptions);
+      const result = getFhirObservations([], defaultOptions);
       expect(result).toEqual([]);
     });
 
@@ -531,7 +531,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations(observations, defaultOptions);
+      const result = getFhirObservations(observations, defaultOptions);
 
       // Empty group members should still produce an observation without hasMember
       expect(result).toHaveLength(1);

--- a/test/helpers/FhirObservationTransformer.test.js
+++ b/test/helpers/FhirObservationTransformer.test.js
@@ -1,4 +1,5 @@
-import transformToFhir from 'src/helpers/FhirObservationTransformer';
+import getFhirObeservations
+ from 'src/helpers/FhirObservationTransformer';
 import {
   FHIR_OBSERVATION_INTERPRETATION_SYSTEM,
   FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL,
@@ -16,17 +17,17 @@ describe('FhirObservationTransformer', () => {
 
   describe('toFhir', () => {
     it('should return empty array for null observations', () => {
-      const result = transformToFhir(null, defaultOptions);
+      const result = getFhirObeservations(null, defaultOptions);
       expect(result).toEqual([]);
     });
 
     it('should return empty array for undefined observations', () => {
-      const result = transformToFhir(undefined, defaultOptions);
+      const result = getFhirObeservations(undefined, defaultOptions);
       expect(result).toEqual([]);
     });
 
     it('should return empty array for non-array observations', () => {
-      const result = transformToFhir('invalid', defaultOptions);
+      const result = getFhirObeservations('invalid', defaultOptions);
       expect(result).toEqual([]);
     });
 
@@ -40,7 +41,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.resourceType).toBe(FHIR_RESOURCE_TYPE_OBSERVATION);
@@ -62,7 +63,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueQuantity).toEqual({ value: 72 });
@@ -76,7 +77,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueBoolean).toBe(true);
@@ -90,7 +91,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueDateTime).toBeDefined();
@@ -106,7 +107,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueDateTime).toBe(dateValue.toISOString());
@@ -120,7 +121,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueCodeableConcept).toBeDefined();
@@ -136,7 +137,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueCodeableConcept.coding[0].display).toBe('Female');
@@ -150,7 +151,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueQuantity).toEqual({ value: 75.5 });
@@ -170,7 +171,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.code.coding[0].code).toBe('concept-uuid-2');
@@ -185,7 +186,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.interpretation).toBeDefined();
@@ -205,7 +206,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result[0].resource.interpretation[0].coding[0].code).toBe('N');
       expect(result[0].resource.interpretation[0].coding[0].display).toBe('Normal');
@@ -221,7 +222,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result[0].resource.extension).toBeDefined();
       const formPathExtension = result[0].resource.extension.find(
@@ -240,7 +241,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       const formPathExtension = result[0].resource.extension?.find(
         (ext) => ext.url === FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL
@@ -257,7 +258,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result[0].resource.note).toBeDefined();
       expect(result[0].resource.note[0].text).toBe('This is a clinical note');
@@ -271,7 +272,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result[0].resource.extension).toBeDefined();
       const complexExtension = result[0].resource.extension.find(
@@ -292,7 +293,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result[0].resource.effectiveDateTime).toBe(obsDatetime);
     });
@@ -307,7 +308,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result[0].resource.effectiveDateTime).toBe(observationDateTime);
     });
@@ -320,7 +321,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result[0].resource.code.coding[0].code).toBe('direct-concept-uuid');
     });
@@ -333,7 +334,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result[0].resource.valueString).toBeUndefined();
     });
@@ -357,7 +358,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       // Should have 3 observations: 2 members + 1 parent
       expect(result).toHaveLength(3);
@@ -394,7 +395,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       // Should have 3 observations: 1 leaf + 1 inner parent + 1 outer parent
       expect(result).toHaveLength(3);
@@ -432,7 +433,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       // Should have 2 observations: 1 active member + 1 parent
       expect(result).toHaveLength(2);
@@ -459,7 +460,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result).toHaveLength(3);
       expect(result[0].resource.valueString).toBe('value1');
@@ -474,7 +475,7 @@ describe('FhirObservationTransformer', () => {
         { concept: { uuid: 'c3' }, value: 'v3' },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       const ids = result.map((r) => r.resource.id);
       const uniqueIds = new Set(ids);
@@ -495,7 +496,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueString).toBeUndefined();
@@ -511,14 +512,15 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueString).toBeUndefined();
     });
 
     it('should handle empty observations array', () => {
-      const result = transformToFhir([], defaultOptions);
+      const result = getFhirObeservations
+      ([], defaultOptions);
       expect(result).toEqual([]);
     });
 
@@ -530,7 +532,8 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformToFhir(observations, defaultOptions);
+      const result = getFhirObeservations
+      (observations, defaultOptions);
 
       // Empty group members should still produce an observation without hasMember
       expect(result).toHaveLength(1);

--- a/test/helpers/FhirObservationTransformer.test.js
+++ b/test/helpers/FhirObservationTransformer.test.js
@@ -1,4 +1,4 @@
-import FhirObservationTransformer from 'src/helpers/FhirObservationTransformer';
+import transformToFhir from 'src/helpers/FhirObservationTransformer';
 import {
   FHIR_OBSERVATION_INTERPRETATION_SYSTEM,
   FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL,
@@ -8,30 +8,25 @@ import {
 } from 'src/constants/fhir';
 
 describe('FhirObservationTransformer', () => {
-  let transformer;
   const defaultOptions = {
     patientReference: { reference: 'Patient/patient-uuid' },
     encounterReference: { reference: 'Encounter/encounter-uuid' },
     performerReference: { reference: 'Practitioner/practitioner-uuid' },
   };
 
-  beforeEach(() => {
-    transformer = new FhirObservationTransformer();
-  });
-
   describe('toFhir', () => {
     it('should return empty array for null observations', () => {
-      const result = transformer.toFhir(null, defaultOptions);
+      const result = transformToFhir(null, defaultOptions);
       expect(result).toEqual([]);
     });
 
     it('should return empty array for undefined observations', () => {
-      const result = transformer.toFhir(undefined, defaultOptions);
+      const result = transformToFhir(undefined, defaultOptions);
       expect(result).toEqual([]);
     });
 
     it('should return empty array for non-array observations', () => {
-      const result = transformer.toFhir('invalid', defaultOptions);
+      const result = transformToFhir('invalid', defaultOptions);
       expect(result).toEqual([]);
     });
 
@@ -45,7 +40,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.resourceType).toBe(FHIR_RESOURCE_TYPE_OBSERVATION);
@@ -67,7 +62,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueQuantity).toEqual({ value: 72 });
@@ -81,7 +76,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueBoolean).toBe(true);
@@ -95,7 +90,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueDateTime).toBeDefined();
@@ -111,7 +106,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueDateTime).toBe(dateValue.toISOString());
@@ -125,7 +120,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueCodeableConcept).toBeDefined();
@@ -141,7 +136,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueCodeableConcept.coding[0].display).toBe('Female');
@@ -155,7 +150,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueQuantity).toEqual({ value: 75.5 });
@@ -175,7 +170,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.code.coding[0].code).toBe('concept-uuid-2');
@@ -190,7 +185,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.interpretation).toBeDefined();
@@ -210,7 +205,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result[0].resource.interpretation[0].coding[0].code).toBe('N');
       expect(result[0].resource.interpretation[0].coding[0].display).toBe('Normal');
@@ -226,7 +221,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result[0].resource.extension).toBeDefined();
       const formPathExtension = result[0].resource.extension.find(
@@ -245,7 +240,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       const formPathExtension = result[0].resource.extension?.find(
         (ext) => ext.url === FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL
@@ -262,7 +257,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result[0].resource.note).toBeDefined();
       expect(result[0].resource.note[0].text).toBe('This is a clinical note');
@@ -276,7 +271,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result[0].resource.extension).toBeDefined();
       const complexExtension = result[0].resource.extension.find(
@@ -297,7 +292,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result[0].resource.effectiveDateTime).toBe(obsDatetime);
     });
@@ -312,7 +307,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result[0].resource.effectiveDateTime).toBe(observationDateTime);
     });
@@ -325,7 +320,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result[0].resource.code.coding[0].code).toBe('direct-concept-uuid');
     });
@@ -338,7 +333,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result[0].resource.valueString).toBeUndefined();
     });
@@ -362,7 +357,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       // Should have 3 observations: 2 members + 1 parent
       expect(result).toHaveLength(3);
@@ -399,7 +394,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       // Should have 3 observations: 1 leaf + 1 inner parent + 1 outer parent
       expect(result).toHaveLength(3);
@@ -437,7 +432,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       // Should have 2 observations: 1 active member + 1 parent
       expect(result).toHaveLength(2);
@@ -464,7 +459,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result).toHaveLength(3);
       expect(result[0].resource.valueString).toBe('value1');
@@ -479,7 +474,7 @@ describe('FhirObservationTransformer', () => {
         { concept: { uuid: 'c3' }, value: 'v3' },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       const ids = result.map((r) => r.resource.id);
       const uniqueIds = new Set(ids);
@@ -500,7 +495,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueString).toBeUndefined();
@@ -516,14 +511,14 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       expect(result).toHaveLength(1);
       expect(result[0].resource.valueString).toBeUndefined();
     });
 
     it('should handle empty observations array', () => {
-      const result = transformer.toFhir([], defaultOptions);
+      const result = transformToFhir([], defaultOptions);
       expect(result).toEqual([]);
     });
 
@@ -535,7 +530,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = transformer.toFhir(observations, defaultOptions);
+      const result = transformToFhir(observations, defaultOptions);
 
       // Empty group members should still produce an observation without hasMember
       expect(result).toHaveLength(1);

--- a/test/helpers/FhirObservationTransformer.test.js
+++ b/test/helpers/FhirObservationTransformer.test.js
@@ -1,0 +1,545 @@
+import FhirObservationTransformer from 'src/helpers/FhirObservationTransformer';
+import {
+  FHIR_OBSERVATION_INTERPRETATION_SYSTEM,
+  FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL,
+  FHIR_OBSERVATION_COMPLEX_DATA_URL,
+  FHIR_OBSERVATION_STATUS_FINAL,
+  FHIR_RESOURCE_TYPE_OBSERVATION,
+} from 'src/constants/fhir';
+
+describe('FhirObservationTransformer', () => {
+  let transformer;
+  const defaultOptions = {
+    patientReference: { reference: 'Patient/patient-uuid' },
+    encounterReference: { reference: 'Encounter/encounter-uuid' },
+    performerReference: { reference: 'Practitioner/practitioner-uuid' },
+  };
+
+  beforeEach(() => {
+    transformer = new FhirObservationTransformer();
+  });
+
+  describe('toFhir', () => {
+    it('should return empty array for null observations', () => {
+      const result = transformer.toFhir(null, defaultOptions);
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array for undefined observations', () => {
+      const result = transformer.toFhir(undefined, defaultOptions);
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array for non-array observations', () => {
+      const result = transformer.toFhir('invalid', defaultOptions);
+      expect(result).toEqual([]);
+    });
+
+    it('should transform a basic observation with string value', () => {
+      const observations = [
+        {
+          concept: { uuid: 'concept-uuid', datatype: 'Text' },
+          value: 'test value',
+          formNamespace: 'Bahmni',
+          formFieldPath: 'TestForm.1/1-0',
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].resource.resourceType).toBe(FHIR_RESOURCE_TYPE_OBSERVATION);
+      expect(result[0].resource.status).toBe(FHIR_OBSERVATION_STATUS_FINAL);
+      expect(result[0].resource.valueString).toBe('test value');
+      expect(result[0].resource.code.coding[0].code).toBe('concept-uuid');
+      expect(result[0].resource.subject).toEqual(defaultOptions.patientReference);
+      expect(result[0].resource.encounter).toEqual(defaultOptions.encounterReference);
+      expect(result[0].resource.performer).toEqual([defaultOptions.performerReference]);
+      expect(result[0].fullUrl).toMatch(/^urn:uuid:/);
+      expect(result[0].resource.id).toBeDefined();
+    });
+
+    it('should transform observation with numeric value', () => {
+      const observations = [
+        {
+          concept: { uuid: 'pulse-uuid', datatype: 'Numeric' },
+          value: 72,
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].resource.valueQuantity).toEqual({ value: 72 });
+    });
+
+    it('should transform observation with boolean value', () => {
+      const observations = [
+        {
+          concept: { uuid: 'smoking-uuid', datatype: 'Boolean' },
+          value: true,
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].resource.valueBoolean).toBe(true);
+    });
+
+    it('should transform observation with date string value', () => {
+      const observations = [
+        {
+          concept: { uuid: 'dob-uuid', datatype: 'Date' },
+          value: '2024-01-15',
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].resource.valueDateTime).toBeDefined();
+      expect(result[0].resource.valueDateTime).toMatch(/^2024-01-15/);
+    });
+
+    it('should transform observation with Date object value', () => {
+      const dateValue = new Date('2024-01-15T10:30:00Z');
+      const observations = [
+        {
+          concept: { uuid: 'datetime-uuid', datatype: 'DateTime' },
+          value: dateValue,
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].resource.valueDateTime).toBe(dateValue.toISOString());
+    });
+
+    it('should transform observation with coded value (uuid object)', () => {
+      const observations = [
+        {
+          concept: { uuid: 'gender-uuid', datatype: 'Coded' },
+          value: { uuid: 'male-uuid', display: 'Male' },
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].resource.valueCodeableConcept).toBeDefined();
+      expect(result[0].resource.valueCodeableConcept.coding[0].code).toBe('male-uuid');
+      expect(result[0].resource.valueCodeableConcept.coding[0].display).toBe('Male');
+    });
+
+    it('should transform observation with coded value using displayString', () => {
+      const observations = [
+        {
+          concept: { uuid: 'gender-uuid', datatype: 'Coded' },
+          value: { uuid: 'female-uuid', displayString: 'Female' },
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].resource.valueCodeableConcept.coding[0].display).toBe('Female');
+    });
+
+    it('should handle numeric string for Numeric datatype', () => {
+      const observations = [
+        {
+          concept: { uuid: 'weight-uuid', datatype: 'Numeric' },
+          value: '75.5',
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].resource.valueQuantity).toEqual({ value: 75.5 });
+    });
+
+    it('should skip voided observations', () => {
+      const observations = [
+        {
+          concept: { uuid: 'concept-uuid' },
+          value: 'test',
+          voided: true,
+        },
+        {
+          concept: { uuid: 'concept-uuid-2' },
+          value: 'test2',
+          voided: false,
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].resource.code.coding[0].code).toBe('concept-uuid-2');
+    });
+
+    it('should include interpretation when provided', () => {
+      const observations = [
+        {
+          concept: { uuid: 'bp-uuid' },
+          value: 140,
+          interpretation: 'ABNORMAL',
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].resource.interpretation).toBeDefined();
+      expect(result[0].resource.interpretation[0].coding[0].system).toBe(
+        FHIR_OBSERVATION_INTERPRETATION_SYSTEM
+      );
+      expect(result[0].resource.interpretation[0].coding[0].code).toBe('A');
+      expect(result[0].resource.interpretation[0].coding[0].display).toBe('Abnormal');
+    });
+
+    it('should handle lowercase interpretation', () => {
+      const observations = [
+        {
+          concept: { uuid: 'bp-uuid' },
+          value: 120,
+          interpretation: 'normal',
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result[0].resource.interpretation[0].coding[0].code).toBe('N');
+      expect(result[0].resource.interpretation[0].coding[0].display).toBe('Normal');
+    });
+
+    it('should include form namespace and field path extension', () => {
+      const observations = [
+        {
+          concept: { uuid: 'concept-uuid' },
+          value: 'test',
+          formNamespace: 'Bahmni',
+          formFieldPath: 'TestForm.1/1-0',
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result[0].resource.extension).toBeDefined();
+      const formPathExtension = result[0].resource.extension.find(
+        (ext) => ext.url === FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL
+      );
+      expect(formPathExtension).toBeDefined();
+      expect(formPathExtension.valueString).toBe('Bahmni^TestForm.1/1-0');
+    });
+
+    it('should not include form path extension when namespace or path is missing', () => {
+      const observations = [
+        {
+          concept: { uuid: 'concept-uuid' },
+          value: 'test',
+          formNamespace: 'Bahmni',
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      const formPathExtension = result[0].resource.extension?.find(
+        (ext) => ext.url === FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL
+      );
+      expect(formPathExtension).toBeUndefined();
+    });
+
+    it('should include comment as note', () => {
+      const observations = [
+        {
+          concept: { uuid: 'concept-uuid' },
+          value: 'test',
+          comment: 'This is a clinical note',
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result[0].resource.note).toBeDefined();
+      expect(result[0].resource.note[0].text).toBe('This is a clinical note');
+    });
+
+    it('should handle complex datatype with attachment extension', () => {
+      const observations = [
+        {
+          concept: { uuid: 'image-uuid', datatype: 'Complex' },
+          value: 'http://example.com/image.jpg',
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result[0].resource.extension).toBeDefined();
+      const complexExtension = result[0].resource.extension.find(
+        (ext) => ext.url === FHIR_OBSERVATION_COMPLEX_DATA_URL
+      );
+      expect(complexExtension).toBeDefined();
+      expect(complexExtension.valueAttachment.url).toBe('http://example.com/image.jpg');
+      expect(result[0].resource.valueString).toBe('http://example.com/image.jpg');
+    });
+
+    it('should use provided obsDatetime', () => {
+      const obsDatetime = '2024-01-15T10:30:00.000Z';
+      const observations = [
+        {
+          concept: { uuid: 'concept-uuid' },
+          value: 'test',
+          obsDatetime,
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result[0].resource.effectiveDateTime).toBe(obsDatetime);
+    });
+
+    it('should use provided observationDateTime (alternate field name)', () => {
+      const observationDateTime = '2024-01-15T10:30:00.000Z';
+      const observations = [
+        {
+          concept: { uuid: 'concept-uuid' },
+          value: 'test',
+          observationDateTime,
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result[0].resource.effectiveDateTime).toBe(observationDateTime);
+    });
+
+    it('should handle concept as string uuid', () => {
+      const observations = [
+        {
+          concept: 'direct-concept-uuid',
+          value: 'test',
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result[0].resource.code.coding[0].code).toBe('direct-concept-uuid');
+    });
+
+    it('should skip empty string values', () => {
+      const observations = [
+        {
+          concept: { uuid: 'concept-uuid' },
+          value: '   ',
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result[0].resource.valueString).toBeUndefined();
+    });
+  });
+
+  describe('group members handling', () => {
+    it('should transform observation with group members', () => {
+      const observations = [
+        {
+          concept: { uuid: 'vitals-group-uuid' },
+          groupMembers: [
+            {
+              concept: { uuid: 'pulse-uuid', datatype: 'Numeric' },
+              value: 72,
+            },
+            {
+              concept: { uuid: 'bp-uuid', datatype: 'Numeric' },
+              value: 120,
+            },
+          ],
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      // Should have 3 observations: 2 members + 1 parent
+      expect(result).toHaveLength(3);
+
+      // Find the parent observation (the one with hasMember)
+      const parentObs = result.find((r) => r.resource.hasMember);
+      expect(parentObs).toBeDefined();
+      expect(parentObs.resource.hasMember).toHaveLength(2);
+
+      // Verify hasMember references point to member observations
+      const memberUrls = result
+        .filter((r) => !r.resource.hasMember)
+        .map((r) => r.fullUrl);
+      parentObs.resource.hasMember.forEach((ref) => {
+        expect(memberUrls).toContain(ref.reference);
+      });
+    });
+
+    it('should handle nested group members', () => {
+      const observations = [
+        {
+          concept: { uuid: 'outer-group-uuid' },
+          groupMembers: [
+            {
+              concept: { uuid: 'inner-group-uuid' },
+              groupMembers: [
+                {
+                  concept: { uuid: 'leaf-uuid' },
+                  value: 'nested value',
+                },
+              ],
+            },
+          ],
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      // Should have 3 observations: 1 leaf + 1 inner parent + 1 outer parent
+      expect(result).toHaveLength(3);
+
+      // Find outer parent (should have hasMember pointing to both inner parent and leaf)
+      // because the recursive call processes all nested members first
+      const outerParent = result.find(
+        (r) => r.resource.code.coding[0].code === 'outer-group-uuid'
+      );
+      expect(outerParent.resource.hasMember).toHaveLength(2);
+
+      // Find inner parent (should have hasMember pointing to leaf)
+      const innerParent = result.find(
+        (r) => r.resource.code.coding[0].code === 'inner-group-uuid'
+      );
+      expect(innerParent.resource.hasMember).toHaveLength(1);
+    });
+
+    it('should skip voided group members', () => {
+      const observations = [
+        {
+          concept: { uuid: 'group-uuid' },
+          groupMembers: [
+            {
+              concept: { uuid: 'member1-uuid' },
+              value: 'active',
+              voided: false,
+            },
+            {
+              concept: { uuid: 'member2-uuid' },
+              value: 'voided',
+              voided: true,
+            },
+          ],
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      // Should have 2 observations: 1 active member + 1 parent
+      expect(result).toHaveLength(2);
+
+      const parentObs = result.find((r) => r.resource.hasMember);
+      expect(parentObs.resource.hasMember).toHaveLength(1);
+    });
+  });
+
+  describe('multiple observations', () => {
+    it('should transform multiple observations', () => {
+      const observations = [
+        {
+          concept: { uuid: 'concept-1' },
+          value: 'value1',
+        },
+        {
+          concept: { uuid: 'concept-2' },
+          value: 42,
+        },
+        {
+          concept: { uuid: 'concept-3' },
+          value: true,
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result).toHaveLength(3);
+      expect(result[0].resource.valueString).toBe('value1');
+      expect(result[1].resource.valueQuantity).toEqual({ value: 42 });
+      expect(result[2].resource.valueBoolean).toBe(true);
+    });
+
+    it('should generate unique UUIDs for each observation', () => {
+      const observations = [
+        { concept: { uuid: 'c1' }, value: 'v1' },
+        { concept: { uuid: 'c2' }, value: 'v2' },
+        { concept: { uuid: 'c3' }, value: 'v3' },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      const ids = result.map((r) => r.resource.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(3);
+
+      const fullUrls = result.map((r) => r.fullUrl);
+      const uniqueUrls = new Set(fullUrls);
+      expect(uniqueUrls.size).toBe(3);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle observation with null value', () => {
+      const observations = [
+        {
+          concept: { uuid: 'concept-uuid' },
+          value: null,
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].resource.valueString).toBeUndefined();
+      expect(result[0].resource.valueQuantity).toBeUndefined();
+      expect(result[0].resource.valueBoolean).toBeUndefined();
+    });
+
+    it('should handle observation with undefined value', () => {
+      const observations = [
+        {
+          concept: { uuid: 'concept-uuid' },
+          value: undefined,
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].resource.valueString).toBeUndefined();
+    });
+
+    it('should handle empty observations array', () => {
+      const result = transformer.toFhir([], defaultOptions);
+      expect(result).toEqual([]);
+    });
+
+    it('should handle observation with empty groupMembers array', () => {
+      const observations = [
+        {
+          concept: { uuid: 'group-uuid' },
+          groupMembers: [],
+        },
+      ];
+
+      const result = transformer.toFhir(observations, defaultOptions);
+
+      // Empty group members should still produce an observation without hasMember
+      expect(result).toHaveLength(1);
+      expect(result[0].resource.hasMember).toBeUndefined();
+    });
+  });
+});

--- a/test/helpers/FhirObservationTransformer.test.js
+++ b/test/helpers/FhirObservationTransformer.test.js
@@ -519,8 +519,7 @@ describe('FhirObservationTransformer', () => {
     });
 
     it('should handle empty observations array', () => {
-      const result = getFhirObeservations
-      ([], defaultOptions);
+      const result = getFhirObeservations([], defaultOptions);
       expect(result).toEqual([]);
     });
 
@@ -532,8 +531,7 @@ describe('FhirObservationTransformer', () => {
         },
       ];
 
-      const result = getFhirObeservations
-      (observations, defaultOptions);
+      const result = getFhirObeservations(observations, defaultOptions);
 
       // Empty group members should still produce an observation without hasMember
       expect(result).toHaveLength(1);


### PR DESCRIPTION
  JIRA - https://bahmni.atlassian.net/browse/BAH-4382

 Summary                                                                                                                                                                      
                                                                                                                                                                               
  Introduces a FHIR Observation transformer to convert form2 observations into FHIR R4-compliant Observation resources, enabling seamless integration with FHIR-based APIs.

 Key Features                                                                                                                                                                 
                                                                                                                                                                               
  - Value Type Support: Handles numeric, string, boolean, date/datetime, coded values, and complex datatypes                                                                   
  - Group Observations: Recursively processes groupMembers with proper hasMember FHIR references                                                                               
  - Extensions: Preserves form namespace/field path and complex data attachments via FHIR extensions                                                                           
  - Interpretation Mapping: Converts ABNORMAL/NORMAL to standard FHIR interpretation codes                                                                                     
  - Clinical Notes: Maps observation comments to FHIR notes                                                                                                                    
  - Voided Filtering: Automatically excludes voided observations                                                                                                                                               
                                                                                                                                                                               
  Exports:                                                                                                                                                                     
  - FhirObservationTransformer class and all FHIR constants exported from src/index.jsx                                                                                        
  - TypeScript definitions added to index.d.ts for FhirReference, FhirTransformOptions, FhirObservationEntry, and the transformer class                                        
                                                                                                                                                                               
  Tests:                                                                                                                                                                       
  - Comprehensive test suite with 545 lines covering all transformation scenarios, edge cases, and group member handling 