### PR TITLE
BAH- 4286-Replace FHIR observation Url with Value-attachment

### DIFF
--- a/src/constants/fhir.js
+++ b/src/constants/fhir.js
@@ -8,7 +8,7 @@ export const FHIR_OBSERVATION_INTERPRETATION_SYSTEM =
 export const FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL =
   'http://fhir.bahmni.org/ext/observation/form-namespace-path';
 
-export const FHIR_OBSERVATION_COMPLEX_DATA_URL =
+export const FHIR_OBSERVATION_VALUE_ATTACHMENT_URL =
   'http://fhir.bahmni.org/ext/observation/obs-value-attachment';
 
 export const CONCEPT_DATATYPE_NUMERIC = 'Numeric';

--- a/src/constants/fhir.js
+++ b/src/constants/fhir.js
@@ -9,7 +9,7 @@ export const FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL =
   'http://fhir.bahmni.org/ext/observation/form-namespace-path';
 
 export const FHIR_OBSERVATION_COMPLEX_DATA_URL =
-  'http://fhir.bahmni.org/ext/observation/complex-data';
+  'http://fhir.bahmni.org/ext/observation/obs-value-attachment';
 
 export const CONCEPT_DATATYPE_NUMERIC = 'Numeric';
 export const CONCEPT_DATATYPE_COMPLEX = 'Complex';


### PR DESCRIPTION
Jira link- https://bahmni.atlassian.net/browse/BAH-4286

Description:

 Replace url  from -http://fhir.bahmni.org/ext/observation/complex-data.  to http://fhir.bahmni.org/ext/observation/complex-data. to http://fhir.bahmni.org/ext/observation/obs-value-attachment. 
and verified the changes under consultation bundle -  image/ video returned under extension/ valueAttachment field as part of History and Examination form