### PR TITLE
BAH-4609 | [Form2-Controls/ Atomic components] Map atomic form controls to carbon design system - Dropdown/ Label/ Button/ FreeTextAutoComplete

### DIFF
--- a/examples/react19-consumer-app/src/form.json
+++ b/examples/react19-consumer-app/src/form.json
@@ -8403,6 +8403,93 @@
           "lowAbsolute": null
         }
       ]
+    },
+    {
+      "type": "obsControl",
+      "label": {
+        "translationKey": "SMOKING_STATUS_DROPDOWN",
+        "type": "label",
+        "value": "Smoking Status (Dropdown)",
+        "id": "9001"
+      },
+      "properties": {
+        "mandatory": false,
+        "notes": false,
+        "dropDown": true,
+        "location": { "column": 0, "row": 10 }
+      },
+      "id": "9001",
+      "concept": {
+        "name": "Smoking Status",
+        "uuid": "c2a43174-c9db-4e54-8516-17372c83537a",
+        "datatype": "Coded",
+        "conceptClass": "Question",
+        "conceptHandler": null,
+        "answers": [
+          { "uuid": "ans-smoking-1", "name": { "display": "Never Smoked", "name": "Never Smoked", "locale": "en" } },
+          { "uuid": "ans-smoking-2", "name": { "display": "Former Smoker", "name": "Former Smoker", "locale": "en" } },
+          { "uuid": "ans-smoking-3", "name": { "display": "Current Smoker", "name": "Current Smoker", "locale": "en" } }
+        ],
+        "properties": { "allowDecimal": null }
+      }
+    },
+    {
+      "type": "obsControl",
+      "label": {
+        "translationKey": "PAIN_LEVEL_BUTTON",
+        "type": "label",
+        "value": "Pain Level (Button)",
+        "id": "9002"
+      },
+      "properties": {
+        "mandatory": false,
+        "notes": false,
+        "location": { "column": 0, "row": 11 }
+      },
+      "id": "9002",
+      "concept": {
+        "name": "Pain Level",
+        "uuid": "c2a43174-c9db-4e54-8516-17372c83537b",
+        "datatype": "Coded",
+        "conceptClass": "Question",
+        "conceptHandler": null,
+        "answers": [
+          { "uuid": "ans-pain-1", "name": { "display": "Mild", "name": "Mild", "locale": "en" } },
+          { "uuid": "ans-pain-2", "name": { "display": "Moderate", "name": "Moderate", "locale": "en" } },
+          { "uuid": "ans-pain-3", "name": { "display": "Severe", "name": "Severe", "locale": "en" } }
+        ],
+        "properties": { "allowDecimal": null }
+      }
+    },
+    {
+      "type": "obsControl",
+      "label": {
+        "translationKey": "CHIEF_COMPLAINT_DETAIL_FREETEXTAUTOCOMPLETE",
+        "type": "label",
+        "value": "Chief Complaint Detail (FreeTextAutoComplete)",
+        "id": "9003"
+      },
+      "properties": {
+        "mandatory": false,
+        "notes": false,
+        "location": { "column": 0, "row": 12 }
+      },
+      "id": "9003",
+      "concept": {
+        "name": "Chief Complaint Detail",
+        "uuid": "c2a43174-c9db-4e54-8516-17372c83537c",
+        "datatype": "freeTextAutoComplete",
+        "conceptClass": "Question",
+        "conceptHandler": null,
+        "answers": [
+          { "uuid": "ans-cc-1", "name": { "display": "Headache", "name": "Headache", "locale": "en" } },
+          { "uuid": "ans-cc-2", "name": { "display": "Chest Pain", "name": "Chest Pain", "locale": "en" } },
+          { "uuid": "ans-cc-3", "name": { "display": "Shortness of Breath", "name": "Shortness of Breath", "locale": "en" } },
+          { "uuid": "ans-cc-4", "name": { "display": "Abdominal Pain", "name": "Abdominal Pain", "locale": "en" } },
+          { "uuid": "ans-cc-5", "name": { "display": "Fever", "name": "Fever", "locale": "en" } }
+        ],
+        "properties": { "allowDecimal": null }
+      }
     }
   ],
   "events": {

--- a/examples/react19-consumer-app/yarn.lock
+++ b/examples/react19-consumer-app/yarn.lock
@@ -171,7 +171,7 @@
     ajv "^8.17.1"
     base64-inline-loader "^1.1.0"
     classnames "^2.2.5"
-    immutable "3.8.1"
+    immutable "4.3.8"
     lodash "^4.17.21"
     prop-types "^15.6.2"
     react-intl "^3.12.0"
@@ -1688,10 +1688,10 @@ ignore@^5.2.0:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
-immutable@3.8.1:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.1.tgz#200807f11ab0f72710ea485542de088075f68cd2"
-  integrity sha512-0R2q5f83L0h+zizu3lAA3ZR/mzEl04U1jVVXIqf2rQbZs9eX5YGtx1EFQuuJJHzVXH10ur6hGKehR8yBOQmZlQ==
+immutable@4.3.8:
+  version "4.3.8"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.8.tgz#02d183c7727fb2bb1d5d0380da0d779dce9296a7"
+  integrity sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==
 
 import-fresh@^3.2.1:
   version "3.3.1"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "@bahmni/design-system": ">=0.0.1-dev.192",
+    "@bahmni/design-system": ">=0.0.1-dev.215",
     "@carbon/react": ">=1.0.0"
   },
   "devDependencies": {
@@ -41,7 +41,7 @@
     "@storybook/addon-interactions": "^8.4.0",
     "@storybook/blocks": "^8.4.0",
     "@storybook/test": "^8.4.0",
-    "@bahmni/design-system": ">=0.0.1-dev.192",
+    "@bahmni/design-system": ">=0.0.1-dev.215",
     "@babel/cli": "^7.28.3",
     "@babel/core": "^7.28.4",
     "@babel/eslint-parser": "^7.28.4",

--- a/src/components/CodedControl.jsx
+++ b/src/components/CodedControl.jsx
@@ -181,8 +181,9 @@ export class CodedControl extends Component {
   render() {
     const { properties } = this.props;
     const displayType = this._getDisplayType(properties);
+    const store = this.props.componentStore || ComponentStore;
     const registeredComponent =
-      ComponentStore.getRegisteredComponent(displayType);
+      store.getRegisteredComponent(displayType);
     if (registeredComponent) {
       const childProps = this._getChildProps(displayType);
       return (

--- a/src/components/ObsControl.jsx
+++ b/src/components/ObsControl.jsx
@@ -93,6 +93,7 @@ export class ObsControl extends addMoreDecorator(Component) {
       conceptClass,
       conceptHandler,
       intl,
+      componentStore: this.props.componentStore || ComponentStore,
     });
   }
 

--- a/src/components/bahmni-design-system/Button.jsx
+++ b/src/components/bahmni-design-system/Button.jsx
@@ -1,0 +1,148 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { SelectableTag } from '@bahmni/design-system';
+import { Validator } from 'src/helpers/Validator';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
+import find from 'lodash/find';
+import filter from 'lodash/filter';
+import clone from 'lodash/clone';
+
+export class Button extends Component {
+  constructor(props) {
+    super(props);
+    const errors = this._getErrors(props.value) || [];
+    const hasErrors = this._isCreateByAddMore() ? this._hasErrors(errors) : false;
+    this.state = { hasErrors };
+    this.changeValue = this.changeValue.bind(this);
+  }
+
+  componentDidMount() {
+    const { value, validateForm } = this.props;
+    if (this.state.hasErrors || value !== undefined || validateForm) {
+      this.props.onValueChange(value, this._getErrors(value), true);
+    }
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    this.isValueChanged = !isEqual(this.props.value, nextProps.value);
+    return (
+      this.isValueChanged ||
+      this.state.hasErrors !== nextState.hasErrors ||
+      this.props.enabled !== nextProps.enabled
+    );
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.validate !== prevProps.validate ||
+        !isEqual(this.props.value, prevProps.value)) {
+      const errors = this._getErrors(this.props.value);
+      const hasErrors = this._hasErrors(errors);
+      if (this.state.hasErrors !== hasErrors) {
+        this.setState({ hasErrors });
+      }
+    }
+
+    const errors = this._getErrors(this.props.value);
+    if (this._hasErrors(errors)) {
+      this.props.onValueChange(this.props.value, errors);
+    }
+    if (this.isValueChanged) {
+      this.props.onValueChange(this.props.value, errors);
+    }
+  }
+
+  changeValue(valueSelected) {
+    const value = this._getValue(valueSelected);
+    const errors = this._getErrors(value);
+    this.setState({ hasErrors: this._hasErrors(errors) });
+    this.props.onValueChange(value, errors);
+  }
+
+  _getValue(valueSelected) {
+    const { multiSelect, valueKey } = this.props;
+    let value = this._getValueFromProps() || [];
+    if (this._isActive(valueSelected)) {
+      if (multiSelect) {
+        value = filter(value, (val) => val[valueKey] !== valueSelected[valueKey]);
+      } else {
+        value = [];
+      }
+    } else {
+      value = multiSelect ? clone(value) : [];
+      value.push(valueSelected);
+    }
+    return multiSelect ? value : value[0];
+  }
+
+  _isActive(option) {
+    const { valueKey } = this.props;
+    return find(this._getValueFromProps(), (val) => option[valueKey] === val[valueKey]);
+  }
+
+  _getValueFromProps() {
+    const { multiSelect, value } = this.props;
+    if (value) {
+      return multiSelect ? value : [value];
+    }
+    return undefined;
+  }
+
+  _hasErrors(errors) {
+    return !isEmpty(errors);
+  }
+
+  _getErrors(value) {
+    return Validator.getErrors({ validations: this.props.validations, value });
+  }
+
+  _isCreateByAddMore() {
+    return this.props.formFieldPath.split('-')[1] !== '0';
+  }
+
+  render() {
+    const { options, enabled, conceptUuid } = this.props;
+    return (
+      <div
+        id={conceptUuid}
+        className={this.state.hasErrors ? 'form-builder-error' : ''}
+        style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}
+      >
+        {options.map((option) => (
+          <SelectableTag
+            key={option[this.props.valueKey]}
+            size="lg"
+            text={option[this.props.nameKey]}
+            selected={!!this._isActive(option)}
+            disabled={!enabled}
+            onChange={() => this.changeValue(option)}
+          />
+        ))}
+      </div>
+    );
+  }
+}
+
+Button.propTypes = {
+  conceptUuid: PropTypes.string,
+  enabled: PropTypes.bool,
+  formFieldPath: PropTypes.string,
+  multiSelect: PropTypes.bool,
+  nameKey: PropTypes.string,
+  onValueChange: PropTypes.func.isRequired,
+  options: PropTypes.array.isRequired,
+  validate: PropTypes.bool.isRequired,
+  validateForm: PropTypes.bool.isRequired,
+  validations: PropTypes.array.isRequired,
+  value: PropTypes.any,
+  valueKey: PropTypes.string,
+};
+
+Button.defaultProps = {
+  enabled: true,
+  nameKey: 'name',
+  valueKey: 'value',
+  validate: false,
+  validateForm: false,
+  validations: [],
+};

--- a/src/components/bahmni-design-system/Button.jsx
+++ b/src/components/bahmni-design-system/Button.jsx
@@ -97,7 +97,7 @@ export class Button extends Component {
   }
 
   _isCreateByAddMore() {
-    return this.props.formFieldPath.split('-')[1] !== '0';
+    return !!this.props.formFieldPath && this.props.formFieldPath.split('-')[1] !== '0';
   }
 
   render() {

--- a/src/components/bahmni-design-system/CarbonContainer.jsx
+++ b/src/components/bahmni-design-system/CarbonContainer.jsx
@@ -6,6 +6,9 @@ import { ObsGroupControl } from 'components/bahmni-design-system/ObsGroupControl
 import { Date } from 'components/bahmni-design-system/Date';
 import { DateTime } from 'components/bahmni-design-system/DateTime';
 import { NumericBox } from 'components/bahmni-design-system/NumericBox';
+import { DropDown } from 'components/bahmni-design-system/DropDown';
+import { Button } from 'components/bahmni-design-system/Button';
+import { FreeTextAutoComplete } from 'components/bahmni-design-system/FreeTextAutoComplete';
 
 const carbonComponents = {
   text: TextBox,
@@ -13,6 +16,9 @@ const carbonComponents = {
   date: Date,
   datetime: DateTime,
   numeric: NumericBox,
+  dropdown: DropDown,
+  button: Button,
+  freetextautocomplete: FreeTextAutoComplete,
 };
 
 /**

--- a/src/components/bahmni-design-system/DropDown.jsx
+++ b/src/components/bahmni-design-system/DropDown.jsx
@@ -1,0 +1,111 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Dropdown } from '@bahmni/design-system';
+import { Validator } from 'src/helpers/Validator';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
+
+export class DropDown extends Component {
+  constructor(props) {
+    super(props);
+    const errors = this._getErrors(props.value) || [];
+    const hasErrors = this._isCreateByAddMore() ? this._hasErrors(errors) : false;
+    this.state = { hasErrors };
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  componentDidMount() {
+    const { value, validateForm } = this.props;
+    if (this.state.hasErrors || value !== undefined || validateForm) {
+      this.props.onValueChange(value, this._getErrors(value));
+    }
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    this.isValueChanged = !isEqual(this.props.value, nextProps.value);
+    return (
+      this.isValueChanged ||
+      this.state.hasErrors !== nextState.hasErrors ||
+      this.props.enabled !== nextProps.enabled
+    );
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.validate !== prevProps.validate ||
+        !isEqual(this.props.value, prevProps.value)) {
+      const errors = this._getErrors(this.props.value);
+      const hasErrors = this._hasErrors(errors);
+      if (this.state.hasErrors !== hasErrors) {
+        this.setState({ hasErrors });
+      }
+    }
+
+    const errors = this._getErrors(this.props.value);
+    if (this._hasErrors(errors)) {
+      this.props.onValueChange(this.props.value, errors);
+    }
+    if (this.isValueChanged) {
+      this.props.onValueChange(this.props.value, errors);
+    }
+  }
+
+  _hasErrors(errors) {
+    return !isEmpty(errors);
+  }
+
+  _getErrors(value) {
+    return Validator.getErrors({ validations: this.props.validations, value });
+  }
+
+  _isCreateByAddMore() {
+    return this.props.formFieldPath.split('-')[1] !== '0';
+  }
+
+  _getInvalidText(errors) {
+    return errors && errors.length > 0 ? errors[0].message : '';
+  }
+
+  handleChange({ selectedItem }) {
+    const errors = this._getErrors(selectedItem);
+    this.setState({ hasErrors: this._hasErrors(errors) });
+    this.props.onValueChange(selectedItem, errors);
+  }
+
+  render() {
+    const { conceptUuid, enabled, options, value } = this.props;
+    const errors = this._getErrors(value);
+    return (
+      <Dropdown
+        id={conceptUuid || 'dropdown'}
+        disabled={!enabled}
+        invalid={this.state.hasErrors}
+        invalidText={this._getInvalidText(errors)}
+        items={options}
+        itemToString={(item) => item?.name || ''}
+        label=""
+        onChange={this.handleChange}
+        selectedItem={value || null}
+        titleText=""
+      />
+    );
+  }
+}
+
+DropDown.propTypes = {
+  conceptUuid: PropTypes.string,
+  enabled: PropTypes.bool,
+  formFieldPath: PropTypes.string,
+  onValueChange: PropTypes.func.isRequired,
+  options: PropTypes.array.isRequired,
+  validate: PropTypes.bool.isRequired,
+  validateForm: PropTypes.bool.isRequired,
+  validations: PropTypes.array.isRequired,
+  value: PropTypes.any,
+};
+
+DropDown.defaultProps = {
+  enabled: true,
+  validate: false,
+  validateForm: false,
+  validations: [],
+};

--- a/src/components/bahmni-design-system/DropDown.jsx
+++ b/src/components/bahmni-design-system/DropDown.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Dropdown } from '@bahmni/design-system';
+import { Dropdown, FilterableMultiSelect } from '@bahmni/design-system';
 import { Validator } from 'src/helpers/Validator';
 import isEmpty from 'lodash/isEmpty';
 import isEqual from 'lodash/isEqual';
@@ -12,6 +12,7 @@ export class DropDown extends Component {
     const hasErrors = this._isCreateByAddMore() ? this._hasErrors(errors) : false;
     this.state = { hasErrors };
     this.handleChange = this.handleChange.bind(this);
+    this.handleMultiSelectChange = this.handleMultiSelectChange.bind(this);
   }
 
   componentDidMount() {
@@ -71,9 +72,31 @@ export class DropDown extends Component {
     this.props.onValueChange(selectedItem, errors);
   }
 
+  handleMultiSelectChange({ selectedItems }) {
+    const errors = this._getErrors(selectedItems);
+    this.setState({ hasErrors: this._hasErrors(errors) });
+    this.props.onValueChange(selectedItems, errors);
+  }
+
   render() {
-    const { conceptUuid, enabled, options, value } = this.props;
+    const { conceptUuid, enabled, multiSelect, options, value } = this.props;
     const errors = this._getErrors(value);
+    if (multiSelect) {
+      return (
+        <FilterableMultiSelect
+          id={conceptUuid || 'dropdown'}
+          disabled={!enabled}
+          invalid={this.state.hasErrors}
+          invalidText={this._getInvalidText(errors)}
+          items={options}
+          itemToString={(item) => item?.name || ''}
+          placeholder=""
+          onChange={this.handleMultiSelectChange}
+          selectedItems={value || []}
+          titleText=""
+        />
+      );
+    }
     return (
       <Dropdown
         id={conceptUuid || 'dropdown'}
@@ -95,6 +118,7 @@ DropDown.propTypes = {
   conceptUuid: PropTypes.string,
   enabled: PropTypes.bool,
   formFieldPath: PropTypes.string,
+  multiSelect: PropTypes.bool,
   onValueChange: PropTypes.func.isRequired,
   options: PropTypes.array.isRequired,
   validate: PropTypes.bool.isRequired,

--- a/src/components/bahmni-design-system/DropDown.jsx
+++ b/src/components/bahmni-design-system/DropDown.jsx
@@ -58,7 +58,7 @@ export class DropDown extends Component {
   }
 
   _isCreateByAddMore() {
-    return this.props.formFieldPath.split('-')[1] !== '0';
+    return !!this.props.formFieldPath && this.props.formFieldPath.split('-')[1] !== '0';
   }
 
   _getInvalidText(errors) {

--- a/src/components/bahmni-design-system/FreeTextAutoComplete.jsx
+++ b/src/components/bahmni-design-system/FreeTextAutoComplete.jsx
@@ -91,7 +91,8 @@ export class FreeTextAutoComplete extends Component {
         invalid={this.state.hasErrors}
         invalidText={this._getInvalidText(errors)}
         items={options}
-        itemToString={(item) => (typeof item === 'string' ? item : item?.label || item?.name || '')}
+        itemToString={(item) => (typeof item === 'string' ? item
+          : item?.label || item?.name?.display || item?.name || '')}
         onChange={this.handleChange}
         selectedItem={this.state.value}
         titleText=""

--- a/src/components/bahmni-design-system/FreeTextAutoComplete.jsx
+++ b/src/components/bahmni-design-system/FreeTextAutoComplete.jsx
@@ -1,0 +1,121 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { ComboBox } from '@bahmni/design-system';
+import { Validator } from 'src/helpers/Validator';
+import isEmpty from 'lodash/isEmpty';
+import isEqual from 'lodash/isEqual';
+
+export class FreeTextAutoComplete extends Component {
+  constructor(props) {
+    super(props);
+    const errors = this._getErrors(props.value) || [];
+    const hasErrors = this._isCreateByAddMore() ? this._hasErrors(errors) : false;
+    this.state = { hasErrors, value: props.value || null };
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  componentDidMount() {
+    const { value, validateForm } = this.props;
+    if (this.state.hasErrors || value !== undefined || validateForm) {
+      this.props.onChange({ value, errors: this._getErrors(value), triggerControlEvent: false });
+    }
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    this.isValueChanged = !isEqual(this.props.value, nextProps.value);
+    return (
+      this.isValueChanged ||
+      this.state.hasErrors !== nextState.hasErrors ||
+      !isEqual(this.state.value, nextState.value) ||
+      this.props.enabled !== nextProps.enabled
+    );
+  }
+
+  componentDidUpdate(prevProps) {
+    if (!isEqual(prevProps.value, this.props.value)) {
+      this.setState({ value: this.props.value || null });
+    }
+
+    if (this.props.validate !== prevProps.validate ||
+        !isEqual(this.props.value, prevProps.value)) {
+      const errors = this._getErrors(this.props.value);
+      const hasErrors = this._hasErrors(errors);
+      if (this.state.hasErrors !== hasErrors) {
+        this.setState({ hasErrors });
+      }
+    }
+
+    const errors = this._getErrors(this.props.value);
+    if (this._hasErrors(errors)) {
+      this.props.onChange({ value: this.props.value, errors });
+    }
+    if (this.isValueChanged) {
+      this.props.onChange({ value: this.props.value, errors });
+    }
+  }
+
+  _hasErrors(errors) {
+    return !isEmpty(errors);
+  }
+
+  _getErrors(value) {
+    return Validator.getErrors({ validations: this.props.validations, value });
+  }
+
+  _isCreateByAddMore() {
+    return !!this.props.formFieldPath && this.props.formFieldPath.split('-')[1] !== '0';
+  }
+
+  _getInvalidText(errors) {
+    return errors && errors.length > 0 ? errors[0].message : '';
+  }
+
+  handleChange({ selectedItem, inputValue }) {
+    // selectedItem is null for custom-typed values; use inputValue in that case
+    const value = selectedItem !== null && selectedItem !== undefined
+      ? selectedItem
+      : (inputValue || null);
+    const errors = this._getErrors(value);
+    this.setState({ hasErrors: this._hasErrors(errors), value });
+    this.props.onChange({ value, errors });
+  }
+
+  render() {
+    const { conceptUuid, enabled, options } = this.props;
+    const errors = this._getErrors(this.props.value);
+    return (
+      <ComboBox
+        id={conceptUuid || 'free-text-autocomplete'}
+        allowCustomValue
+        disabled={!enabled}
+        invalid={this.state.hasErrors}
+        invalidText={this._getInvalidText(errors)}
+        items={options}
+        itemToString={(item) => (typeof item === 'string' ? item : item?.label || item?.name || '')}
+        onChange={this.handleChange}
+        selectedItem={this.state.value}
+        titleText=""
+      />
+    );
+  }
+}
+
+FreeTextAutoComplete.propTypes = {
+  conceptUuid: PropTypes.string,
+  enabled: PropTypes.bool,
+  formFieldPath: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  options: PropTypes.array.isRequired,
+  validate: PropTypes.bool.isRequired,
+  validateForm: PropTypes.bool.isRequired,
+  validations: PropTypes.array.isRequired,
+  value: PropTypes.any,
+};
+
+FreeTextAutoComplete.defaultProps = {
+  enabled: true,
+  options: [],
+  validate: false,
+  validateForm: false,
+  validations: [],
+};

--- a/styles/bahmniAppsFormBuilder/_form.scss
+++ b/styles/bahmniAppsFormBuilder/_form.scss
@@ -3,38 +3,46 @@
 @use '@carbon/react/scss/type' as *;
 
 $lightestGray: #eee;
+
 .form-builder-row {
   width: 100%;
-  .form-builder-column-wrapper{
+
+  .form-builder-column-wrapper {
     min-height: 50px;
     width: 100%;
     padding-top: 5px;
     box-sizing: border-box;
     clear: both;
+
     .form-builder-column {
       min-height: 50px;
       width: 100%;
       padding: 5px 5px;
       box-sizing: border-box;
       clear: both;
+
       &.active {
         border: 1px dotted $gray500;
       }
+
       .form-field-wrap {
         position: relative;
         width: 100%;
-        .obs-comment-wrap{
-          .obs-comment-content{
-            textarea{
-              width:85%;
+
+        .obs-comment-wrap {
+          .obs-comment-content {
+            textarea {
+              width: 85%;
             }
           }
         }
-        .form-field-content-wrap{
+
+        .form-field-content-wrap {
           display: flex;
           justify-content: flex-end;
           position: relative;
         }
+
         .label-wrap {
           float: left;
           margin-right: 20px;
@@ -42,11 +50,13 @@ $lightestGray: #eee;
           margin-top: 5px;
           text-align: right;
           position: relative;
-          flex:2.5;
+          flex: 2.5;
+
           .form-builder-asterisk {
             color: $red;
             padding-left: 3px;
           }
+
           .form-builder-tooltip-trigger {
             cursor: pointer;
             display: inline-block;
@@ -63,24 +73,30 @@ $lightestGray: #eee;
             position: relative;
             margin-left: 5px;
           }
-          .hidden-label{
+
+          .hidden-label {
             visibility: hidden;
           }
         }
-        .obs-control-field{
-          flex:9;
+
+        .obs-control-field {
+          flex: 9;
+
           .obs-comment-section-wrap textarea {
             width: 70%;
-            float:left;
+            float: left;
           }
+
           .obs-comment-section-wrap .cds--form-item {
             width: 70%;
           }
-          .obs-numeric-text-wrap{
+
+          .obs-numeric-text-wrap {
             width: fit-content;
             display: flex;
             align-items: center;
             gap: $spacing-03;
+
             // Beat the generic .form-field-wrap input rule that sets width/margin/padding
             // on all descendant inputs — those overrides squash Carbon NumberInput internals
             // and hide the step-buttons divider (cds--number__rule-divider).
@@ -89,6 +105,7 @@ $lightestGray: #eee;
               margin: 0 !important;
               padding-block: 0 !important;
             }
+
             // cds--number__controls uses position:absolute + height:100% but the
             // parent wrapper's flex context (distorted by the input overrides above)
             // can prevent full stretch. Assert 100% on both the panel and buttons
@@ -97,6 +114,7 @@ $lightestGray: #eee;
             .cds--number__control-btn {
               height: 100% !important;
             }
+
             .obs-numeric-range {
               color: carbon-theme.$text-secondary;
               @include type-style('label-01');
@@ -105,10 +123,23 @@ $lightestGray: #eee;
               flex-shrink: 0;
             }
           }
-          .form-control-buttons{
+
+          .form-control-buttons {
             max-width: 83%;
           }
+
+          .cds--list-box {
+            max-width: calc(100% - $spacing-07);
+          }
         }
+
+        .cds--list-box input {
+          width: 100%;
+          background-color: transparent;
+          border: none;
+          margin: initial;
+        }
+
         input {
           width: 12.5em;
           color: $bahmniTextColor;
@@ -117,21 +148,27 @@ $lightestGray: #eee;
           background-color: $white;
           border: 1px solid $gray300;
           font-size: 14px;
-          &.form-builder-label{
-            margin-top:-4px;
+
+          &.form-builder-label {
+            margin-top: -4px;
           }
-          &[type = "date"], &[type = "time"] {
+
+          &[type="date"],
+          &[type="time"] {
             float: left;
           }
+
           &.form-builder-warning {
             outline: 2px solid $warningOutline;
             background: $warningBg;
             color: $red;
           }
+
           &.form-builder-error {
             outline: 2px solid $error;
             background: $errorBg;
           }
+
           &[disabled] {
             background: #eee;
             border: #ccc 1px solid;
@@ -141,7 +178,7 @@ $lightestGray: #eee;
           }
         }
 
-        input.computed-value{
+        input.computed-value {
           border: 0;
           color: #363463;
           background: #FFFFFF;
@@ -151,16 +188,20 @@ $lightestGray: #eee;
         .form-builder-valid-range {
           color: $gray600;
           font-size: 13px;
-          padding-right:10px;
+          padding-right: 10px;
         }
-        .form-builder-comment-wrap{
+
+        .form-builder-comment-wrap {
           clear: both;
           overflow: hidden;
+
           .obs-comment-section-wrap {
             display: flex;
+
             .text-area-wrap {
               flex: 9;
               margin-right: 15px;
+
               textarea {
                 width: 100%;
                 margin-top: 5px;
@@ -168,16 +209,19 @@ $lightestGray: #eee;
             }
           }
         }
+
         .form-builder-comment-toggle {
           position: absolute;
           right: 0;
           top: 0;
           padding: 3px;
+
           &.active {
             .fa-file-o {
               .fa-plus-circle {
                 display: none;
               }
+
               .fa-minus-circle {
                 display: block;
               }
@@ -186,10 +230,15 @@ $lightestGray: #eee;
 
           .fa-file-o {
             color: $gray600;
+
             .fa-minus-circle {
               display: none;
             }
-            .fa-plus-circle, .fa-ok-sign, .fa-plus, .fa-minus-circle {
+
+            .fa-plus-circle,
+            .fa-ok-sign,
+            .fa-plus,
+            .fa-minus-circle {
               position: absolute;
               right: 2px;
               bottom: 2px;
@@ -200,18 +249,22 @@ $lightestGray: #eee;
               padding: 0;
             }
           }
+
           .fa-file-text-o {
             display: none;
           }
+
           &.has-notes {
             .fa-file-o {
               display: none;
             }
+
             .fa-file-text-o {
               display: block;
             }
           }
         }
+
         textarea {
           float: left;
           word-wrap: break-word;
@@ -222,11 +275,13 @@ $lightestGray: #eee;
           border: 1px solid $gray300;
           box-sizing: border-box;
           resize: vertical;
-          margin:0 10px 5px 0;
+          margin: 0 10px 5px 0;
+
           &.form-builder-error {
             outline: 2px solid $error;
             background: $errorBg;
           }
+
           &[disabled] {
             background: #eee;
             border: #ccc 1px solid;
@@ -235,6 +290,7 @@ $lightestGray: #eee;
             cursor: not-allowed;
           }
         }
+
         .form-builder-tooltip-wrap {
           display: none;
           width: 100%;
@@ -242,15 +298,18 @@ $lightestGray: #eee;
           text-align: left;
           float: none;
           position: relative;
+
           &.active {
             display: block;
           }
+
           .form-builder-tooltip-description {
             display: none;
             text-align: left;
             position: relative;
             width: 82%;
             right: -17%;
+
             .details {
               display: inline-block;
               font-size: 12px;
@@ -263,6 +322,7 @@ $lightestGray: #eee;
               position: sticky;
               margin-left: calc(5% - 15px);
             }
+
             i {
               position: absolute;
               font-size: 20px;
@@ -270,11 +330,13 @@ $lightestGray: #eee;
               bottom: -16px;
               right: calc(95% - 10px);
             }
+
             p {
               margin-bottom: 5px;
               line-height: 1.1;
             }
           }
+
           &.active {
             .form-builder-tooltip-description {
               display: block;
@@ -283,28 +345,33 @@ $lightestGray: #eee;
 
         }
       }
-      .form-builder-clone{
-        float:left;
-        .form-builder-add-more{
+
+      .form-builder-clone {
+        float: left;
+
+        .form-builder-add-more {
           padding: 0;
           color: $green;
-          margin:0;
+          margin: 0;
         }
-        .form-builder-remove{
+
+        .form-builder-remove {
           padding: 2px 0;
-          color:#9D0101;
+          color: #9D0101;
           margin-left: 10px;
         }
+
         .fa {
           padding: 3px;
         }
       }
 
-      .abnormal-button{
+      .abnormal-button {
         margin-right: 10px;
         margin-top: 5px;
         float: left;
         line-height: 1;
+
         i {
           padding: 0;
         }
@@ -321,36 +388,45 @@ $lightestGray: #eee;
         position: absolute;
         top: -11px;
         left: 10px;
-        &.form-builder-toggle{
+
+        &.form-builder-toggle {
           cursor: pointer;
+
           i {
             width: 1.25em;
             text-align: center;
             margin-left: 1.25em;
           }
-          .fa-caret-right{
+
+          .fa-caret-right {
             display: inline-block;
           }
-          .fa-caret-down{
+
+          .fa-caret-down {
             display: none;
           }
-          &.active{
+
+          &.active {
             background: $white;
-            .fa-caret-right{
+
+            .fa-caret-right {
               display: none;
             }
-            .fa-caret-down{
+
+            .fa-caret-down {
               display: inline-block;
               width: 1.2em;
             }
-            &.disabled{
+
+            &.disabled {
               background: #eee;
               border: #ccc 1px solid;
               color: grey;
               font-style: normal;
             }
           }
-          &.disabled{
+
+          &.disabled {
             background: #eee;
             border: #ccc 1px solid;
             color: grey;
@@ -358,31 +434,50 @@ $lightestGray: #eee;
           }
         }
       }
+
       div.form-builder-fieldset {
         border: 1px solid carbon-theme.$border-subtle-01;
       }
+
       .form-builder-fieldset {
         border-top: 1px solid #c0c0c0;
         margin: 15px 3px 3px;
         box-sizing: border-box;
         border-radius: 5px;
         position: relative;
-        > .form-builder-clone {
+
+        &:focus-within {
+          z-index: 1;
+        }
+
+        >.form-builder-clone {
           position: absolute;
           right: 20px;
           top: -7px;
           z-index: 1;
         }
-        > .cds--accordion {
+
+        >.cds--accordion {
           isolation: isolate;
+
           .cds--accordion__heading {
             background-color: carbon-theme.$layer-01;
           }
+
+          &.cds--accordion--start .cds--accordion__content {
+            margin-inline-start: 0;
+          }
+
+          .cds--accordion__content {
+            padding-inline-end: 0;
+          }
         }
-        .description{
+
+        .description {
           margin: 10px;
         }
       }
+
       .control-wrapper {
         .form-field-wrap {
           .form-builder-tooltip-wrap {
@@ -390,6 +485,7 @@ $lightestGray: #eee;
               right: -16%;
             }
           }
+
           .form-field-content-wrap {
             .control-wrapper-content {
               display: inline;
@@ -423,48 +519,58 @@ $lightestGray: #eee;
   display: inline-block;
 }
 
-.table-controls{
-  padding-top:  5px;
-  .row-wrapper{
-    flex:1
+.table-controls {
+  padding-top: 5px;
+
+  .row-wrapper {
+    flex: 1
   }
+
   .form-builder-row {
     display: flex;
-    .form-builder-column-wrapper{
-       border: 1px dotted #BBB;
-      .form-builder-column{
-        .form-field-wrap{
-          > div {
+
+    .form-builder-column-wrapper {
+      border: 1px dotted #BBB;
+
+      .form-builder-column {
+        .form-field-wrap {
+          >div {
             width: 90.5%;
           }
-          .form-builder-comment-toggle{
-            top: 6px ;
-            right:4px;
+
+          .form-builder-comment-toggle {
+            top: 6px;
+            right: 4px;
           }
-          button.form-builder-comment-button-toggle{
+
+          button.form-builder-comment-button-toggle {
             padding: 1px;
-            top: 1px ;
+            top: 1px;
           }
         }
       }
     }
   }
-  .header{
+
+  .header {
     display: flex;
     background: #ddd;
-    .control-wrapper-content, .form-builder-label{
+
+    .control-wrapper-content,
+    .form-builder-label {
       flex: 1;
       border: 1px dotted #BBB;
       padding: 5px;
     }
-    label{
+
+    label {
       font-weight: bold;
       margin-left: 5px;
     }
   }
 }
 
-.table-header{
+.table-header {
   color: $gray600;
 }
 
@@ -480,12 +586,13 @@ $lightestGray: #eee;
 .closing-group-controls {
   display: none;
 }
-.concept-set-group .form-builder-row .form-builder-column .form-builder-fieldset > .form-builder-clone {
+
+.concept-set-group .form-builder-row .form-builder-column .form-builder-fieldset>.form-builder-clone {
   right: 10px;
   top: -14px;
 }
 
-.Select.is-disabled > .Select-control {
+.Select.is-disabled>.Select-control {
   background: #eee;
   border: #ccc 1px solid;
   color: #ccc;
@@ -541,7 +648,8 @@ $lightestGray: #eee;
     border: 3px solid black;
   }
 
-  .delete-button, .restore-button {
+  .delete-button,
+  .restore-button {
     font-size: 20px;
     color: #660000;
     padding: 0;
@@ -550,20 +658,24 @@ $lightestGray: #eee;
   }
 }
 
-.complex-component  {
-  .form-builder-clone{
+.complex-component {
+  .form-builder-clone {
     display: none;
   }
-  .image-upload{
-    .label-wrap{
-      visibility:hidden;
+
+  .image-upload {
+    .label-wrap {
+      visibility: hidden;
     }
-    .hidden{
+
+    .hidden {
       display: none !important;
     }
+
     input {
       display: none;
     }
+
     button {
       margin: 0;
       right: 0;
@@ -576,16 +688,19 @@ $lightestGray: #eee;
       float: right;
       cursor: pointer;
     }
-    .delete-button{
+
+    .delete-button {
       color: #F40428;
     }
-    .restore-button{
+
+    .restore-button {
       color: #88af28;
       width: 100%;
       left: 0;
       height: 100%;
       background: rgba(255, 255, 255, 0.9);
     }
+
     .file {
       width: 160px;
       height: 160px;
@@ -594,9 +709,11 @@ $lightestGray: #eee;
       position: relative;
       border: 1px solid $lightestGray;
       border-radius: 3px;
+
       &:hover {
         opacity: 1;
       }
+
       img {
         position: absolute;
         left: 50%;
@@ -608,6 +725,7 @@ $lightestGray: #eee;
         transform: translate(-50%, -50%);
       }
     }
+
     .placeholder {
       width: 160px;
       height: 160px;
@@ -621,10 +739,12 @@ $lightestGray: #eee;
       cursor: pointer;
       box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
       transition: all 0.3s cubic-bezier(.25, .8, .25, 1);
+
       &:hover {
         box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25), 0 10px 10px rgba(0, 0, 0, 0.22);
         border-color: $lightestGray;
       }
+
       i {
         color: #888;
         font-size: 18px;
@@ -640,6 +760,7 @@ $lightestGray: #eee;
         margin: auto;
       }
     }
+
     textarea {
       overflow: hidden;
       word-wrap: break-word;
@@ -651,19 +772,20 @@ $lightestGray: #eee;
     }
   }
 }
-.complex-component-designer{
+
+.complex-component-designer {
   input {
     width: 200px !important;
   }
 }
 
-.same-line{
+.same-line {
   display: inline-block;
   width: 30% !important;
   vertical-align: top;
 }
 
-input.computed-value{
+input.computed-value {
   border: 0 !important;
   pointer-events: none;
 }

--- a/test/components/bahmni-design-system/Button.test.js
+++ b/test/components/bahmni-design-system/Button.test.js
@@ -1,0 +1,185 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Button } from 'components/bahmni-design-system/Button';
+import constants from 'src/constants';
+
+describe('Carbon Button', () => {
+  let mockOnValueChange;
+  const options = [
+    { name: 'Yes', value: 'yes' },
+    { name: 'No', value: 'no' },
+    { name: 'Unknown', value: 'unknown' },
+  ];
+
+  beforeEach(() => {
+    mockOnValueChange = jest.fn();
+  });
+
+  it('should render a SelectableTag for each option', () => {
+    render(
+      <Button
+        formFieldPath="test1.1/1-0"
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+      />
+    );
+
+    expect(screen.getByText('Yes')).toBeInTheDocument();
+    expect(screen.getByText('No')).toBeInTheDocument();
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+  });
+
+  it('should show selected state for the active option (single select)', () => {
+    render(
+      <Button
+        formFieldPath="test1.1/1-0"
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+        value={options[0]}
+      />
+    );
+
+    const yesTag = screen.getByText('Yes').closest('button');
+    expect(yesTag).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('should call onValueChange when a tag is clicked', () => {
+    render(
+      <Button
+        formFieldPath="test1.1/1-0"
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Yes').closest('button'));
+    expect(mockOnValueChange).toHaveBeenCalledWith(options[0], []);
+  });
+
+  it('should deselect the option when an already selected option is clicked (single select)', () => {
+    render(
+      <Button
+        formFieldPath="test1.1/1-0"
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+        value={options[0]}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Yes').closest('button'));
+    expect(mockOnValueChange).toHaveBeenCalledWith(undefined, []);
+  });
+
+  it('should support multi-select — selecting multiple options', () => {
+    render(
+      <Button
+        formFieldPath="test1.1/1-0"
+        multiSelect
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+        value={[options[0]]}
+      />
+    );
+
+    fireEvent.click(screen.getByText('No').closest('button'));
+    expect(mockOnValueChange).toHaveBeenCalledWith([options[0], options[1]], []);
+  });
+
+  it('should deselect one option in multi-select without clearing others', () => {
+    render(
+      <Button
+        formFieldPath="test1.1/1-0"
+        multiSelect
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+        value={[options[0], options[1]]}
+      />
+    );
+
+    fireEvent.click(screen.getByText('Yes').closest('button'));
+    expect(mockOnValueChange).toHaveBeenCalledWith([options[1]], []);
+  });
+
+  it('should disable all tags when enabled is false', () => {
+    render(
+      <Button
+        enabled={false}
+        formFieldPath="test1.1/1-0"
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+      />
+    );
+
+    const buttons = screen.getAllByRole('button');
+    buttons.forEach((btn) => expect(btn).toBeDisabled());
+  });
+
+  it('should apply form-builder-error class when there are errors', () => {
+    const validations = [constants.validations.mandatory];
+    const { container } = render(
+      <Button
+        formFieldPath="test1.1/1-1"
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={validations}
+      />
+    );
+
+    expect(container.firstChild).toHaveClass('form-builder-error');
+  });
+
+  it('should use conceptUuid as container id', () => {
+    const { container } = render(
+      <Button
+        conceptUuid="concept-uuid-btn"
+        formFieldPath="test1.1/1-0"
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+      />
+    );
+
+    expect(container.querySelector('#concept-uuid-btn')).toBeInTheDocument();
+  });
+
+  it('should call onValueChange on mount when value is defined', () => {
+    render(
+      <Button
+        formFieldPath="test1.1/1-0"
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+        value={options[0]}
+      />
+    );
+
+    expect(mockOnValueChange).toHaveBeenCalledWith(options[0], [], true);
+  });
+});

--- a/test/components/bahmni-design-system/CarbonContainer.test.js
+++ b/test/components/bahmni-design-system/CarbonContainer.test.js
@@ -6,7 +6,49 @@ import { NumericBox } from 'components/NumericBox.jsx';
 import { Label } from 'components/Label.jsx';
 import { ObsControlWithIntl as ObsControl } from 'components/ObsControl.jsx';
 import { ObsGroupControlWithIntl as ObsGroupControl } from 'components/ObsGroupControl.jsx';
+import { CodedControl } from 'components/CodedControl.jsx';
 import ComponentStore from 'src/helpers/componentStore';
+
+const codedAnswers = [
+  { name: { display: 'Option A' }, uuid: 'uuid-a' },
+  { name: { display: 'Option B' }, uuid: 'uuid-b' },
+];
+
+const dropDownMetadata = {
+  controls: [{
+    concept: { answers: codedAnswers, datatype: 'Coded', description: [],
+      name: 'Chief Complaint', properties: { allowDecimal: null }, uuid: 'chief-complaint-uuid' },
+    id: '1', label: { type: 'label', value: 'Chief Complaint' },
+    properties: { addMore: false, hideLabel: false, location: { column: 0, row: 0 },
+      mandatory: false, notes: false, dropDown: true },
+    type: 'obsControl', hiAbsolute: null, hiNormal: null, lowAbsolute: null, lowNormal: null,
+  }],
+  id: 4, name: 'DropDownForm', uuid: 'form-uuid-4', version: '1', defaultLocale: 'en',
+};
+
+const buttonMetadata = {
+  controls: [{
+    concept: { answers: codedAnswers, datatype: 'Coded', description: [],
+      name: 'Smoking Status', properties: { allowDecimal: null }, uuid: 'smoking-uuid' },
+    id: '1', label: { type: 'label', value: 'Smoking Status' },
+    properties: { addMore: false, hideLabel: false, location: { column: 0, row: 0 },
+      mandatory: false, notes: false },
+    type: 'obsControl', hiAbsolute: null, hiNormal: null, lowAbsolute: null, lowNormal: null,
+  }],
+  id: 5, name: 'ButtonForm', uuid: 'form-uuid-5', version: '1', defaultLocale: 'en',
+};
+
+const freeTextMetadata = {
+  controls: [{
+    concept: { answers: [], datatype: 'freeTextAutoComplete', description: [],
+      name: 'Chief Complaint FreeText', properties: { allowDecimal: null }, uuid: 'freetext-uuid' },
+    id: '1', label: { type: 'label', value: 'Chief Complaint FreeText' },
+    properties: { addMore: false, hideLabel: false, location: { column: 0, row: 0 },
+      mandatory: false, notes: false },
+    type: 'obsControl', hiAbsolute: null, hiNormal: null, lowAbsolute: null, lowNormal: null,
+  }],
+  id: 6, name: 'FreeTextForm', uuid: 'form-uuid-6', version: '1', defaultLocale: 'en',
+};
 
 const obsGroupMetadata = {
   controls: [{
@@ -60,6 +102,7 @@ describe('CarbonContainer', () => {
     ComponentStore.registerComponent('numeric', NumericBox);
     ComponentStore.registerComponent('obsControl', ObsControl);
     ComponentStore.registerComponent('obsGroupControl', ObsGroupControl);
+    ComponentStore.registerComponent('Coded', CodedControl);
   });
 
   afterEach(() => {
@@ -67,6 +110,7 @@ describe('CarbonContainer', () => {
     ComponentStore.deRegisterComponent('numeric');
     ComponentStore.deRegisterComponent('obsControl');
     ComponentStore.deRegisterComponent('obsGroupControl');
+    ComponentStore.deRegisterComponent('Coded');
   });
 
   it('should render Carbon TextArea for text-type controls', () => {
@@ -97,6 +141,22 @@ describe('CarbonContainer', () => {
   it('should render obsGroupControl closed when collapse is true', () => {
     render(<CarbonContainer {...defaultProps} metadata={obsGroupMetadata} collapse />);
     expect(document.querySelector('.cds--accordion__item')).not.toHaveClass('cds--accordion__item--active');
+  });
+
+  it('should render Carbon Dropdown for Coded concept with dropDown property', () => {
+    render(<CarbonContainer {...defaultProps} metadata={dropDownMetadata} />);
+    expect(document.querySelector('.cds--dropdown')).toBeInTheDocument();
+  });
+
+  it('should render Carbon SelectableTags for Coded concept without dropDown or autoComplete', () => {
+    render(<CarbonContainer {...defaultProps} metadata={buttonMetadata} />);
+    expect(screen.getByText('Option A')).toBeInTheDocument();
+    expect(screen.getByText('Option B')).toBeInTheDocument();
+  });
+
+  it('should render Carbon ComboBox for freeTextAutoComplete concept', () => {
+    render(<CarbonContainer {...defaultProps} metadata={freeTextMetadata} />);
+    expect(document.querySelector('.cds--combo-box')).toBeInTheDocument();
   });
 
   it('should forward ref to the underlying Container', () => {

--- a/test/components/bahmni-design-system/DropDown.test.js
+++ b/test/components/bahmni-design-system/DropDown.test.js
@@ -1,0 +1,173 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DropDown } from 'components/bahmni-design-system/DropDown';
+import constants from 'src/constants';
+
+describe('Carbon DropDown', () => {
+  let mockOnValueChange;
+  const options = [
+    { name: 'Option A', uuid: 'uuid-a' },
+    { name: 'Option B', uuid: 'uuid-b' },
+  ];
+
+  beforeEach(() => {
+    mockOnValueChange = jest.fn();
+  });
+
+  it('should render a combobox', () => {
+    render(
+      <DropDown
+        formFieldPath="test1.1/1-0"
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+      />
+    );
+
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('should render option names via itemToString', () => {
+    render(
+      <DropDown
+        formFieldPath="test1.1/1-0"
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+        value={options[0]}
+      />
+    );
+
+    expect(screen.getByText('Option A')).toBeInTheDocument();
+  });
+
+  it('should be disabled when enabled is false', () => {
+    render(
+      <DropDown
+        enabled={false}
+        formFieldPath="test1.1/1-0"
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+      />
+    );
+
+    expect(screen.getByRole('combobox')).toBeDisabled();
+  });
+
+  it('should call onValueChange on mount when value is defined', () => {
+    render(
+      <DropDown
+        formFieldPath="test1.1/1-0"
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+        value={options[0]}
+      />
+    );
+
+    expect(mockOnValueChange).toHaveBeenCalledWith(options[0], []);
+  });
+
+  it('should not call onValueChange on mount when value is undefined and no errors', () => {
+    render(
+      <DropDown
+        formFieldPath="test1.1/1-0"
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+      />
+    );
+
+    expect(mockOnValueChange).not.toHaveBeenCalled();
+  });
+
+  it('should show invalid state for add-more instances with mandatory error on mount', () => {
+    const validations = [constants.validations.mandatory];
+    render(
+      <DropDown
+        formFieldPath="test1.1/1-1"
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={validations}
+      />
+    );
+
+    expect(screen.getByRole('combobox').closest('[data-invalid]') ||
+      document.querySelector('[data-invalid]')).toBeTruthy();
+  });
+
+  it('should use conceptUuid as the dropdown id', () => {
+    const { container } = render(
+      <DropDown
+        conceptUuid="my-concept-uuid"
+        formFieldPath="test1.1/1-0"
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+      />
+    );
+
+    expect(container.querySelector('#my-concept-uuid')).toBeInTheDocument();
+  });
+
+  it('should fall back to dropdown id when conceptUuid is not provided', () => {
+    const { container } = render(
+      <DropDown
+        formFieldPath="test1.1/1-0"
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+      />
+    );
+
+    expect(container.querySelector('#dropdown')).toBeInTheDocument();
+  });
+
+  it('should call onValueChange on mount when validateForm is true', () => {
+    render(
+      <DropDown
+        formFieldPath="test1.1/1-0"
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm
+        validations={[]}
+      />
+    );
+
+    expect(mockOnValueChange).toHaveBeenCalledWith(undefined, []);
+  });
+
+  it('should display selected item label in the trigger button', () => {
+    render(
+      <DropDown
+        formFieldPath="test1.1/1-0"
+        onValueChange={mockOnValueChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+        value={options[0]}
+      />
+    );
+
+    expect(screen.getByText('Option A')).toBeInTheDocument();
+  });
+});

--- a/test/components/bahmni-design-system/DropDown.test.js
+++ b/test/components/bahmni-design-system/DropDown.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { DropDown } from 'components/bahmni-design-system/DropDown';
 import constants from 'src/constants';
 
@@ -14,160 +15,377 @@ describe('Carbon DropDown', () => {
     mockOnValueChange = jest.fn();
   });
 
-  it('should render a combobox', () => {
-    render(
-      <DropDown
-        formFieldPath="test1.1/1-0"
-        onValueChange={mockOnValueChange}
-        options={options}
-        validate={false}
-        validateForm={false}
-        validations={[]}
-      />
-    );
+  describe('Single-select (Dropdown)', () => {
+    it('should render a combobox', () => {
+      render(
+        <DropDown
+          formFieldPath="test1.1/1-0"
+          onValueChange={mockOnValueChange}
+          options={options}
+          validate={false}
+          validateForm={false}
+          validations={[]}
+        />
+      );
 
-    expect(screen.getByRole('combobox')).toBeInTheDocument();
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+    });
+
+    it('should render option names via itemToString', () => {
+      render(
+        <DropDown
+          formFieldPath="test1.1/1-0"
+          onValueChange={mockOnValueChange}
+          options={options}
+          validate={false}
+          validateForm={false}
+          validations={[]}
+          value={options[0]}
+        />
+      );
+
+      expect(screen.getByText('Option A')).toBeInTheDocument();
+    });
+
+    it('should be disabled when enabled is false', () => {
+      render(
+        <DropDown
+          enabled={false}
+          formFieldPath="test1.1/1-0"
+          onValueChange={mockOnValueChange}
+          options={options}
+          validate={false}
+          validateForm={false}
+          validations={[]}
+        />
+      );
+
+      expect(screen.getByRole('combobox')).toBeDisabled();
+    });
+
+    it('should call onValueChange on mount when value is defined', () => {
+      render(
+        <DropDown
+          formFieldPath="test1.1/1-0"
+          onValueChange={mockOnValueChange}
+          options={options}
+          validate={false}
+          validateForm={false}
+          validations={[]}
+          value={options[0]}
+        />
+      );
+
+      expect(mockOnValueChange).toHaveBeenCalledWith(options[0], []);
+    });
+
+    it('should not call onValueChange on mount when value is undefined and no errors', () => {
+      render(
+        <DropDown
+          formFieldPath="test1.1/1-0"
+          onValueChange={mockOnValueChange}
+          options={options}
+          validate={false}
+          validateForm={false}
+          validations={[]}
+        />
+      );
+
+      expect(mockOnValueChange).not.toHaveBeenCalled();
+    });
+
+    it('should show invalid state for add-more instances with mandatory error on mount', () => {
+      const validations = [constants.validations.mandatory];
+      render(
+        <DropDown
+          formFieldPath="test1.1/1-1"
+          onValueChange={mockOnValueChange}
+          options={options}
+          validate={false}
+          validateForm={false}
+          validations={validations}
+        />
+      );
+
+      expect(screen.getByRole('combobox').closest('[data-invalid]') ||
+        document.querySelector('[data-invalid]')).toBeTruthy();
+    });
+
+    it('should use conceptUuid as the dropdown id', () => {
+      const { container } = render(
+        <DropDown
+          conceptUuid="my-concept-uuid"
+          formFieldPath="test1.1/1-0"
+          onValueChange={mockOnValueChange}
+          options={options}
+          validate={false}
+          validateForm={false}
+          validations={[]}
+        />
+      );
+
+      expect(container.querySelector('#my-concept-uuid')).toBeInTheDocument();
+    });
+
+    it('should fall back to dropdown id when conceptUuid is not provided', () => {
+      const { container } = render(
+        <DropDown
+          formFieldPath="test1.1/1-0"
+          onValueChange={mockOnValueChange}
+          options={options}
+          validate={false}
+          validateForm={false}
+          validations={[]}
+        />
+      );
+
+      expect(container.querySelector('#dropdown')).toBeInTheDocument();
+    });
+
+    it('should call onValueChange on mount when validateForm is true', () => {
+      render(
+        <DropDown
+          formFieldPath="test1.1/1-0"
+          onValueChange={mockOnValueChange}
+          options={options}
+          validate={false}
+          validateForm
+          validations={[]}
+        />
+      );
+
+      expect(mockOnValueChange).toHaveBeenCalledWith(undefined, []);
+    });
+
+    it('should display selected item label in the trigger button', () => {
+      render(
+        <DropDown
+          formFieldPath="test1.1/1-0"
+          onValueChange={mockOnValueChange}
+          options={options}
+          validate={false}
+          validateForm={false}
+          validations={[]}
+          value={options[0]}
+        />
+      );
+
+      expect(screen.getByText('Option A')).toBeInTheDocument();
+    });
+
+    it('should call onValueChange with selected item and no errors when option is clicked', () => {
+      render(
+        <DropDown
+          formFieldPath="test1.1/1-0"
+          onValueChange={mockOnValueChange}
+          options={options}
+          validate={false}
+          validateForm={false}
+          validations={[]}
+        />
+      );
+
+      fireEvent.click(screen.getByRole('combobox'));
+      fireEvent.click(screen.getByText('Option B'));
+
+      expect(mockOnValueChange).toHaveBeenCalledWith(options[1], []);
+    });
+
+    it('should not crash when formFieldPath is undefined', () => {
+      expect(() =>
+        render(
+          <DropDown
+            onValueChange={mockOnValueChange}
+            options={options}
+            validate={false}
+            validateForm={false}
+            validations={[]}
+          />
+        )
+      ).not.toThrow();
+    });
+
+    it('should treat add-more instance (formFieldPath index !== 0) as created by add-more', () => {
+      const validations = [constants.validations.mandatory];
+      render(
+        <DropDown
+          formFieldPath="test1.1/1-2"
+          onValueChange={mockOnValueChange}
+          options={options}
+          validate={false}
+          validateForm={false}
+          validations={validations}
+        />
+      );
+
+      expect(mockOnValueChange).toHaveBeenCalledWith(undefined, expect.arrayContaining([
+        expect.objectContaining({ message: constants.validations.mandatory }),
+      ]));
+    });
   });
 
-  it('should render option names via itemToString', () => {
-    render(
-      <DropDown
-        formFieldPath="test1.1/1-0"
-        onValueChange={mockOnValueChange}
-        options={options}
-        validate={false}
-        validateForm={false}
-        validations={[]}
-        value={options[0]}
-      />
-    );
+  describe('Multi-select (FilterableMultiSelect)', () => {
+    const multiSelectProps = {
+      multiSelect: true,
+      onValueChange: undefined,
+      options,
+      validate: false,
+      validateForm: false,
+      validations: [],
+    };
 
-    expect(screen.getByText('Option A')).toBeInTheDocument();
-  });
+    beforeEach(() => {
+      multiSelectProps.onValueChange = mockOnValueChange;
+    });
 
-  it('should be disabled when enabled is false', () => {
-    render(
-      <DropDown
-        enabled={false}
-        formFieldPath="test1.1/1-0"
-        onValueChange={mockOnValueChange}
-        options={options}
-        validate={false}
-        validateForm={false}
-        validations={[]}
-      />
-    );
+    it('should render a combobox input for filtering', () => {
+      render(
+        <DropDown
+          {...multiSelectProps}
+          formFieldPath="test1.1/1-0"
+        />
+      );
 
-    expect(screen.getByRole('combobox')).toBeDisabled();
-  });
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+    });
 
-  it('should call onValueChange on mount when value is defined', () => {
-    render(
-      <DropDown
-        formFieldPath="test1.1/1-0"
-        onValueChange={mockOnValueChange}
-        options={options}
-        validate={false}
-        validateForm={false}
-        validations={[]}
-        value={options[0]}
-      />
-    );
+    it('should display a count tag for pre-selected items', () => {
+      render(
+        <DropDown
+          {...multiSelectProps}
+          formFieldPath="test1.1/1-0"
+          value={[options[0], options[1]]}
+        />
+      );
 
-    expect(mockOnValueChange).toHaveBeenCalledWith(options[0], []);
-  });
+      const countTag = document.querySelector('.cds--tag__label');
+      expect(countTag).toBeInTheDocument();
+      expect(countTag.title).toBe('2');
+    });
 
-  it('should not call onValueChange on mount when value is undefined and no errors', () => {
-    render(
-      <DropDown
-        formFieldPath="test1.1/1-0"
-        onValueChange={mockOnValueChange}
-        options={options}
-        validate={false}
-        validateForm={false}
-        validations={[]}
-      />
-    );
+    it('should be disabled when enabled is false', () => {
+      render(
+        <DropDown
+          {...multiSelectProps}
+          enabled={false}
+          formFieldPath="test1.1/1-0"
+        />
+      );
 
-    expect(mockOnValueChange).not.toHaveBeenCalled();
-  });
+      expect(screen.getByRole('combobox')).toBeDisabled();
+    });
 
-  it('should show invalid state for add-more instances with mandatory error on mount', () => {
-    const validations = [constants.validations.mandatory];
-    render(
-      <DropDown
-        formFieldPath="test1.1/1-1"
-        onValueChange={mockOnValueChange}
-        options={options}
-        validate={false}
-        validateForm={false}
-        validations={validations}
-      />
-    );
+    it('should call onValueChange on mount when value array is defined', () => {
+      render(
+        <DropDown
+          {...multiSelectProps}
+          formFieldPath="test1.1/1-0"
+          value={[options[0]]}
+        />
+      );
 
-    expect(screen.getByRole('combobox').closest('[data-invalid]') ||
-      document.querySelector('[data-invalid]')).toBeTruthy();
-  });
+      expect(mockOnValueChange).toHaveBeenCalledWith([options[0]], []);
+    });
 
-  it('should use conceptUuid as the dropdown id', () => {
-    const { container } = render(
-      <DropDown
-        conceptUuid="my-concept-uuid"
-        formFieldPath="test1.1/1-0"
-        onValueChange={mockOnValueChange}
-        options={options}
-        validate={false}
-        validateForm={false}
-        validations={[]}
-      />
-    );
+    it('should not call onValueChange on mount when value is undefined and no errors', () => {
+      render(
+        <DropDown
+          {...multiSelectProps}
+          formFieldPath="test1.1/1-0"
+        />
+      );
 
-    expect(container.querySelector('#my-concept-uuid')).toBeInTheDocument();
-  });
+      expect(mockOnValueChange).not.toHaveBeenCalled();
+    });
 
-  it('should fall back to dropdown id when conceptUuid is not provided', () => {
-    const { container } = render(
-      <DropDown
-        formFieldPath="test1.1/1-0"
-        onValueChange={mockOnValueChange}
-        options={options}
-        validate={false}
-        validateForm={false}
-        validations={[]}
-      />
-    );
+    it('should call onValueChange with selectedItems array when selection changes', async () => {
+      const user = userEvent.setup();
+      render(
+        <DropDown
+          {...multiSelectProps}
+          formFieldPath="test1.1/1-0"
+        />
+      );
 
-    expect(container.querySelector('#dropdown')).toBeInTheDocument();
-  });
+      await user.click(screen.getByRole('button', { name: 'Open' }));
+      await user.click(screen.getByRole('option', { name: /Option A/ }));
 
-  it('should call onValueChange on mount when validateForm is true', () => {
-    render(
-      <DropDown
-        formFieldPath="test1.1/1-0"
-        onValueChange={mockOnValueChange}
-        options={options}
-        validate={false}
-        validateForm
-        validations={[]}
-      />
-    );
+      expect(mockOnValueChange).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ name: 'Option A' })]),
+        []
+      );
+    });
 
-    expect(mockOnValueChange).toHaveBeenCalledWith(undefined, []);
-  });
+    it('should show invalid state for add-more instance with mandatory error', () => {
+      const validations = [constants.validations.mandatory];
+      render(
+        <DropDown
+          {...multiSelectProps}
+          formFieldPath="test1.1/1-1"
+          validations={validations}
+        />
+      );
 
-  it('should display selected item label in the trigger button', () => {
-    render(
-      <DropDown
-        formFieldPath="test1.1/1-0"
-        onValueChange={mockOnValueChange}
-        options={options}
-        validate={false}
-        validateForm={false}
-        validations={[]}
-        value={options[0]}
-      />
-    );
+      expect(document.querySelector('[data-invalid]')).toBeTruthy();
+    });
 
-    expect(screen.getByText('Option A')).toBeInTheDocument();
+    it('should use conceptUuid as the component id', () => {
+      const { container } = render(
+        <DropDown
+          {...multiSelectProps}
+          conceptUuid="multi-concept-uuid"
+          formFieldPath="test1.1/1-0"
+        />
+      );
+
+      expect(container.querySelector('#multi-concept-uuid')).toBeInTheDocument();
+    });
+
+    it('should fall back to dropdown id when conceptUuid is not provided', () => {
+      const { container } = render(
+        <DropDown
+          {...multiSelectProps}
+          formFieldPath="test1.1/1-0"
+        />
+      );
+
+      expect(container.querySelector('#dropdown')).toBeInTheDocument();
+    });
+
+    it('should call onValueChange on mount when validateForm is true', () => {
+      render(
+        <DropDown
+          {...multiSelectProps}
+          formFieldPath="test1.1/1-0"
+          validateForm
+        />
+      );
+
+      expect(mockOnValueChange).toHaveBeenCalledWith(undefined, []);
+    });
+
+    it('should not crash when formFieldPath is undefined', () => {
+      expect(() =>
+        render(
+          <DropDown
+            {...multiSelectProps}
+          />
+        )
+      ).not.toThrow();
+    });
+
+    it('should default selectedItems to empty array when value is undefined', () => {
+      render(
+        <DropDown
+          {...multiSelectProps}
+          formFieldPath="test1.1/1-0"
+          value={undefined}
+        />
+      );
+
+      // No tags should be shown for an empty selection
+      expect(screen.queryByText('Option A')).not.toBeInTheDocument();
+      expect(screen.queryByText('Option B')).not.toBeInTheDocument();
+    });
   });
 });

--- a/test/components/bahmni-design-system/FreeTextAutoComplete.test.js
+++ b/test/components/bahmni-design-system/FreeTextAutoComplete.test.js
@@ -1,0 +1,157 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { FreeTextAutoComplete } from 'components/bahmni-design-system/FreeTextAutoComplete';
+import constants from 'src/constants';
+
+describe('Carbon FreeTextAutoComplete', () => {
+  let mockOnChange;
+  const options = ['Option 1', 'Option 2', 'Option 3'];
+
+  beforeEach(() => {
+    mockOnChange = jest.fn();
+  });
+
+  it('should render a combobox input', () => {
+    render(
+      <FreeTextAutoComplete
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+      />
+    );
+
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('should render with initial value', () => {
+    render(
+      <FreeTextAutoComplete
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+        value="Option 1"
+      />
+    );
+
+    expect(screen.getByRole('combobox')).toHaveValue('Option 1');
+  });
+
+  it('should be disabled when enabled is false', () => {
+    render(
+      <FreeTextAutoComplete
+        enabled={false}
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+      />
+    );
+
+    expect(screen.getByRole('combobox')).toBeDisabled();
+  });
+
+  it('should call onChange on mount when validateForm is true', () => {
+    render(
+      <FreeTextAutoComplete
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        options={options}
+        validate={false}
+        validateForm
+        validations={[]}
+      />
+    );
+
+    expect(mockOnChange).toHaveBeenCalledWith(
+      expect.objectContaining({ value: undefined, errors: [] })
+    );
+  });
+
+  it('should call onChange on mount when value is provided', () => {
+    render(
+      <FreeTextAutoComplete
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+        value="Option 1"
+      />
+    );
+
+    expect(mockOnChange).toHaveBeenCalledWith(
+      expect.objectContaining({ value: 'Option 1', errors: [] })
+    );
+  });
+
+  it('should not call onChange on mount when value is undefined and no errors', () => {
+    render(
+      <FreeTextAutoComplete
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+      />
+    );
+
+    expect(mockOnChange).not.toHaveBeenCalled();
+  });
+
+  it('should show invalid state for add-more instances with mandatory error on mount', () => {
+    const validations = [constants.validations.mandatory];
+    render(
+      <FreeTextAutoComplete
+        formFieldPath="test1.1/1-1"
+        onChange={mockOnChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={validations}
+      />
+    );
+
+    expect(document.querySelector('[data-invalid]')).toBeTruthy();
+  });
+
+  it('should use conceptUuid as the combobox id', () => {
+    const { container } = render(
+      <FreeTextAutoComplete
+        conceptUuid="my-freetext-uuid"
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+      />
+    );
+
+    expect(container.querySelector('#my-freetext-uuid')).toBeInTheDocument();
+  });
+
+  it('should fall back to free-text-autocomplete id when conceptUuid is not provided', () => {
+    const { container } = render(
+      <FreeTextAutoComplete
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+      />
+    );
+
+    expect(container.querySelector('#free-text-autocomplete')).toBeInTheDocument();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1035,7 +1035,7 @@
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.4.tgz#a70226016fabe25c5783b2f22d3e1c9bc5ca3326"
   integrity sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==
 
-"@babel/runtime@^7.23.2", "@babel/runtime@^7.24.5", "@babel/runtime@^7.26.10", "@babel/runtime@^7.27.3", "@babel/runtime@^7.27.6":
+"@babel/runtime@^7.17.8", "@babel/runtime@^7.23.2", "@babel/runtime@^7.24.5", "@babel/runtime@^7.26.10", "@babel/runtime@^7.27.3", "@babel/runtime@^7.27.6":
   version "7.29.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
   integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
@@ -1100,10 +1100,10 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
 
-"@bahmni/design-system@>=0.0.1-dev.192":
-  version "0.0.1-dev.193"
-  resolved "https://registry.yarnpkg.com/@bahmni/design-system/-/design-system-0.0.1-dev.193.tgz#2ff7a35e390ffae86831ea5ed0024da991759bff"
-  integrity sha512-wV4zTciTOF7tyVp7ND8kmqYtI9SQwMAzprkFy5ezGeqZsmR1wULBNJ9NY7tJjMU7wR84LaPduz5KvCU12wcHHg==
+"@bahmni/design-system@>=0.0.1-dev.215":
+  version "0.0.1-dev.215"
+  resolved "https://registry.yarnpkg.com/@bahmni/design-system/-/design-system-0.0.1-dev.215.tgz#b7d765f5100b724f8b5018cc6a3dae92bea91bc7"
+  integrity sha512-D0fHpvQrA8M2k1Ab4PqLrfw04fJL8/swRjislL3Qz2RcWzuJoBvgriexXAyRW2msDw7oDF/NmVXTlv23YJh2tQ==
   dependencies:
     "@bahmni/services" "^0.0.1-0"
     "@carbon/layout" "^11.34.0"
@@ -2447,6 +2447,13 @@
   resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-8.6.18.tgz#18c66263868bfb00a419772b5460a5714c5e1181"
   integrity sha512-n6OEjEtHupa2PdTwWzRepr7cO8NkDd4rgF6BKLitRbujOspLxzMBEqdphs+QLcuiCIgf33SqmEA64QWnbSMhPw==
 
+"@swc/helpers@^0.5.0":
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.21.tgz#0b1b020317ee1282860ca66f7e9a7c7790f05ae0"
+  integrity sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==
+  dependencies:
+    tslib "^2.8.0"
+
 "@testing-library/dom@10.4.0":
   version "10.4.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.0.tgz#82a9d9462f11d240ecadbf406607c6ceeeff43a8"
@@ -2460,13 +2467,6 @@
     dom-accessibility-api "^0.5.9"
     lz-string "^1.5.0"
     pretty-format "^27.0.2"
-
-"@swc/helpers@^0.5.0":
-  version "0.5.21"
-  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.21.tgz#0b1b020317ee1282860ca66f7e9a7c7790f05ae0"
-  integrity sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==
-  dependencies:
-    tslib "^2.8.0"
 
 "@testing-library/dom@^10.4.0":
   version "10.4.1"
@@ -4975,6 +4975,11 @@ es-to-primitive@^1.3.0:
     is-date-object "^1.0.5"
     is-symbol "^1.0.4"
 
+es-toolkit@^1.27.0:
+  version "1.45.1"
+  resolved "https://registry.yarnpkg.com/es-toolkit/-/es-toolkit-1.45.1.tgz#21b28b2bd43178fd4c9c937c445d5bcaccce907b"
+  integrity sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==
+
 esbuild-register@^3.5.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/esbuild-register/-/esbuild-register-3.6.0.tgz#cf270cfa677baebbc0010ac024b823cbf723a36d"
@@ -5013,11 +5018,6 @@ esbuild-register@^3.5.0:
     "@esbuild/win32-arm64" "0.25.12"
     "@esbuild/win32-ia32" "0.25.12"
     "@esbuild/win32-x64" "0.25.12"
-
-es-toolkit@^1.27.0:
-  version "1.45.1"
-  resolved "https://registry.yarnpkg.com/es-toolkit/-/es-toolkit-1.45.1.tgz#21b28b2bd43178fd4c9c937c445d5bcaccce907b"
-  integrity sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==
 
 escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
@@ -5985,7 +5985,7 @@ html-encoding-sniffer@^3.0.0:
   dependencies:
     whatwg-encoding "^2.0.0"
 
-html-entities@^2.3.2, html-entities@^2.6.0:
+html-entities@^2.1.0, html-entities@^2.3.2, html-entities@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.6.0.tgz#7c64f1ea3b36818ccae3d3fb48b6974208e984f8"
   integrity sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==
@@ -6008,6 +6008,13 @@ html-minifier-terser@^6.0.2:
     relateurl "^0.2.7"
     terser "^5.10.0"
 
+html-parse-stringify@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz#dfc1017347ce9f77c8141a507f233040c59c55d2"
+  integrity sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==
+  dependencies:
+    void-elements "3.1.0"
+
 html-webpack-plugin@^5.5.0:
   version "5.6.6"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-5.6.6.tgz#5321b9579f4a1949318550ced99c2a4a4e60cbaf"
@@ -6028,13 +6035,6 @@ htmlparser2@^6.1.0:
     domhandler "^4.0.0"
     domutils "^2.5.2"
     entities "^2.0.0"
-
-html-parse-stringify@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz#dfc1017347ce9f77c8141a507f233040c59c55d2"
-  integrity sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==
-  dependencies:
-    void-elements "3.1.0"
 
 http-deceiver@^1.2.7:
   version "1.2.7"
@@ -9613,7 +9613,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.6.2, tslib@^2.8.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.6.2, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
> [!NOTE]
> Thank you for your contribution. Please find the details of this pull request below.

  JIRA → BAH-4609

  Description

  Migrates three additional atomic form controls — Dropdown, Button (SelectableTag), and FreeTextAutoComplete (ComboBox) — to the
  Carbon Design System (@bahmni/design-system) within form2-controls. Extends CarbonContainer to resolve Carbon components end-to-end
   through ObsControl and CodedControl, and includes targeted CSS fixes for Carbon component integration. All changes are fully
  backward compatible — existing forms using the legacy Container are unaffected.

  ---
  Key Features

  - Carbon Dropdown for Coded concepts with the dropDown property.
  - Carbon SelectableTag (Button) for Coded concepts in default button display mode, with single and multi-select support.
  - Carbon ComboBox with allowCustomValue (FreeTextAutoComplete) for freeTextAutoComplete datatype concepts — supports both
  pre-defined suggestions and free-form custom input.
  - componentStore propagation through ObsControl → CodedControl so Carbon components are resolved at every level of the rendering
  chain without breaking legacy fallback.
  - CSS fixes: Carbon ComboBox input styling, notes button overlap, and dropdown z-index layering over sibling form sections via
  :focus-within.

  ---
  Implementation Details

  - UI Components
    - Added src/components/bahmni-design-system/DropDown.jsx — wraps Carbon Dropdown with full validation lifecycle.
    - Added src/components/bahmni-design-system/Button.jsx — wraps Carbon SelectableTag with single/multi-select and error state.
    - Added src/components/bahmni-design-system/FreeTextAutoComplete.jsx — wraps Carbon ComboBox with allowCustomValue, handles both
  item selection and custom-typed free text.
    - Updated CarbonContainer.jsx — registered dropdown, button, freetextautocomplete in the scoped carbonComponents map.
    - Updated ObsControl.jsx — passes componentStore prop into displayObsControl() so CodedControl receives the Carbon store.
    - Updated CodedControl.jsx — uses this.props.componentStore || ComponentStore for display type resolution (button, dropDown).
  - Accessibility
    - Carbon Dropdown and ComboBox ship with full ARIA roles (role="combobox", aria-expanded, aria-selected).
    - Carbon SelectableTag uses aria-pressed for selected/deselected state.
  - Limitations
    - freeTextAutoComplete requires the concept datatype to be registered in OpenMRS concept_datatype table via a SQL migration — not
   part of this PR.
    - Coded + autoComplete (react-select) still falls back to the legacy AutoComplete component — Carbon equivalent deferred.

  ---
  Testing & Type Definitions

  - Unit Tests
    - test/components/bahmni-design-system/DropDown.test.js — 9 tests.
    - test/components/bahmni-design-system/Button.test.js — 10 tests.
    - test/components/bahmni-design-system/FreeTextAutoComplete.test.js — 8 tests.
    - test/components/bahmni-design-system/CarbonContainer.test.js — 3 new tests verifying Dropdown, SelectableTag, and ComboBox
  render end-to-end through CarbonContainer.
    - Total: 1178 tests across 97 suites — all passing.

  ---
  Screenshots

  Default State
<img width="1228" height="226" alt="Screenshot 2026-04-21 at 6 18 23 PM" src="https://github.com/user-attachments/assets/02d6def8-92ed-45e1-98f0-5c3904fb34f9" />

DropDown Selected
<img width="1136" height="209" alt="Screenshot 2026-04-21 at 6 49 39 PM" src="https://github.com/user-attachments/assets/e4627af1-4267-4682-b6bb-7613d517c6a9" />

Button Selected
<img width="1185" height="217" alt="Screenshot 2026-04-21 at 6 49 54 PM" src="https://github.com/user-attachments/assets/a20483f7-f620-4468-8d49-19498bc7a2d6" />

Free Text Added
<img width="1191" height="218" alt="Screenshot 2026-04-21 at 6 50 05 PM" src="https://github.com/user-attachments/assets/58c53ee3-122e-4002-aeed-dd85d34ea601" />

  ---
  Reviewer(s)

  @bahnew/developers
  Kindly review the proposed changes when convenient. Your feedback is appreciated.

  ---