### PR TITLE
BAH-4642 | Migrate ObsControl CSS Layout to Carbon Design System

### DIFF
--- a/examples/react19-consumer-app/src/form.json
+++ b/examples/react19-consumer-app/src/form.json
@@ -3780,7 +3780,7 @@
             "value": "Chief Complaint"
           },
           "properties": {
-            "mandatory": false,
+            "mandatory": true,
             "notes": false,
             "addMore": false,
             "hideLabel": false,
@@ -7688,7 +7688,7 @@
         "value": "History of present illness"
       },
       "properties": {
-        "mandatory": false,
+        "mandatory": true,
         "notes": false,
         "addMore": false,
         "hideLabel": false,
@@ -8630,7 +8630,7 @@
         "value": "Diagnosis (AutoComplete)"
       },
       "properties": {
-        "mandatory": false,
+        "mandatory": true,
         "notes": false,
         "addMore": false,
         "hideLabel": false,

--- a/src/components/Container.jsx
+++ b/src/components/Container.jsx
@@ -179,7 +179,10 @@ export class Container extends addMoreDecorator(Component) {
   render() {
     const { metadata: { controls,
       name: formName, version: formVersion }, validate, translations, patient, readonly } = this.props;
-    const formTranslations = { ...translations.labels, ...translations.concepts };
+    const formTranslations = Object.fromEntries(
+      Object.entries({ ...translations.labels, ...translations.concepts })
+        .filter(([key, value]) => value !== key)
+    );
     const patientUuid = patient ? patient.uuid : undefined;
     const childProps = {
       collapse: this.state.collapse,

--- a/src/components/bahmni-design-system/AutoComplete.jsx
+++ b/src/components/bahmni-design-system/AutoComplete.jsx
@@ -151,9 +151,6 @@ export const AutoComplete = forwardRef(function AutoComplete({
     const newHasErrors = hasErrors(errors);
     setValue(propValue);
     setHasError(newHasErrors);
-    if (onValueChange && (newHasErrors || validateChanged)) {
-      onValueChange(propValue, errors);
-    }
   }, [propValue, validate, validations, onValueChange]);
 
   // Update options when searchable=false and options change
@@ -231,7 +228,6 @@ export const AutoComplete = forwardRef(function AutoComplete({
           id={conceptUuid}
           disabled={!enabled}
           invalid={hasError}
-          invalidText={hasError ? (getErrors(validations, propValue)?.[0]?.message || 'Invalid value') : ''}
           items={safeOptions}
           itemToString={(item) => (item ? item[labelKey] || '' : '')}
           selectedItem={value || null}
@@ -253,7 +249,6 @@ export const AutoComplete = forwardRef(function AutoComplete({
         id={conceptUuid}
         disabled={!enabled}
         invalid={hasError}
-        invalidText={hasError ? (getErrors(validations, propValue)?.[0]?.message || 'Invalid value') : ''}
         items={safeOptions}
         itemToString={(item) => (item ? item[labelKey] || '' : '')}
         selectedItem={value || null}

--- a/src/components/bahmni-design-system/Button.jsx
+++ b/src/components/bahmni-design-system/Button.jsx
@@ -7,6 +7,7 @@ import isEqual from 'lodash/isEqual';
 import find from 'lodash/find';
 import filter from 'lodash/filter';
 import clone from 'lodash/clone';
+import constants from 'src/constants';
 
 export class Button extends Component {
   constructor(props) {
@@ -29,7 +30,8 @@ export class Button extends Component {
     return (
       this.isValueChanged ||
       this.state.hasErrors !== nextState.hasErrors ||
-      this.props.enabled !== nextProps.enabled
+      this.props.enabled !== nextProps.enabled ||
+      this.props.validate !== nextProps.validate
     );
   }
 
@@ -43,11 +45,8 @@ export class Button extends Component {
       }
     }
 
-    const errors = this._getErrors(this.props.value);
-    if (this._hasErrors(errors)) {
-      this.props.onValueChange(this.props.value, errors);
-    }
     if (this.isValueChanged) {
+      const errors = this._getErrors(this.props.value);
       this.props.onValueChange(this.props.value, errors);
     }
   }
@@ -89,7 +88,7 @@ export class Button extends Component {
   }
 
   _hasErrors(errors) {
-    return !isEmpty(errors);
+    return !isEmpty(errors.filter(e => e.type !== constants.errorTypes.warning));
   }
 
   _getErrors(value) {

--- a/src/components/bahmni-design-system/Button.jsx
+++ b/src/components/bahmni-design-system/Button.jsx
@@ -105,7 +105,7 @@ export class Button extends Component {
       <div
         id={conceptUuid}
         className={this.state.hasErrors ? 'form-builder-error' : ''}
-        style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}
+        style={{ display: 'inline-flex', flexWrap: 'wrap', gap: 'var(--cds-spacing-03)' }}
       >
         {options.map((option) => (
           <SelectableTag

--- a/src/components/bahmni-design-system/CarbonContainer.jsx
+++ b/src/components/bahmni-design-system/CarbonContainer.jsx
@@ -13,6 +13,7 @@ import { FreeTextAutoComplete } from 'components/bahmni-design-system/FreeTextAu
 import { AutoComplete } from 'components/bahmni-design-system/AutoComplete';
 import { Location } from 'components/bahmni-design-system/Location';
 import { Provider } from 'components/bahmni-design-system/Provider';
+import { ObsControlWithIntl } from 'components/bahmni-design-system/ObsControl';
 import { RadioButton } from 'components/bahmni-design-system/RadioButton';
 
 const carbonComponents = {
@@ -28,6 +29,7 @@ const carbonComponents = {
   autocomplete: AutoComplete,
   locationobshandler: Location,
   providerobshandler: Provider,
+  obscontrol: ObsControlWithIntl,
   radio: RadioButton,
 };
 

--- a/src/components/bahmni-design-system/Comment.jsx
+++ b/src/components/bahmni-design-system/Comment.jsx
@@ -1,0 +1,87 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { TextArea } from '@bahmni/design-system';
+import { Util } from 'src/helpers/Util';
+
+export class Comment extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      showCommentSection: false,
+      comment: props.comment || '',
+    };
+    this.handleChange = this.handleChange.bind(this);
+  }
+
+  handleChange(e) {
+    const raw = e.target.value;
+    this.setState({ comment: raw });
+    const trimmed = raw.trim();
+    this.props.onCommentChange(trimmed !== '' ? trimmed : undefined);
+  }
+
+  showCommentSection(isComplexMediaConcept) {
+    if (this.state.showCommentSection || (isComplexMediaConcept && this.props.value)) {
+      return (
+        <div className="obs-comment-section-wrap">
+          <TextArea
+            id={this.props.conceptUuid}
+            labelText=""
+            maxLength={255}
+            onChange={this.handleChange}
+            placeholder="Notes"
+            rows={3}
+            value={this.state.comment}
+          />
+        </div>
+      );
+    }
+    return null;
+  }
+
+  showCommentButton(isComplexMediaConcept) {
+    if (isComplexMediaConcept) {
+      return '';
+    }
+    const { showCommentSection, comment } = this.state;
+    const hasNote = comment.trim().length > 0;
+    return (
+      <button
+        className={[
+          'form-builder-comment-toggle',
+          'form-builder-comment-button-toggle',
+          showCommentSection ? 'active' : '',
+          hasNote ? 'has-notes' : '',
+        ].filter(Boolean).join(' ')}
+        onClick={() => this.setState({ showCommentSection: !showCommentSection })}
+      >
+        <i className="fa fa-file-o">
+          <i className="fa fa-plus-circle" />
+          <i className="fa fa-minus-circle" />
+        </i>
+        <i className="fa fa-file-text-o" />
+      </button>
+    );
+  }
+
+  render() {
+    const { conceptHandler, datatype } = this.props;
+    const isComplexMediaConcept = Util.isComplexMediaConcept({ conceptHandler, datatype });
+    return (
+      <div className="form-builder-comment-wrap">
+        {this.showCommentButton(isComplexMediaConcept)}
+        {this.showCommentSection(isComplexMediaConcept)}
+      </div>
+    );
+  }
+}
+
+Comment.propTypes = {
+  comment: PropTypes.string,
+  conceptHandler: PropTypes.string,
+  conceptUuid: PropTypes.string,
+  datatype: PropTypes.string,
+  onCommentChange: PropTypes.func.isRequired,
+  value: PropTypes.string,
+};

--- a/src/components/bahmni-design-system/Comment.jsx
+++ b/src/components/bahmni-design-system/Comment.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { TextArea } from '@bahmni/design-system';
+import { TextArea, SelectableTag } from '@bahmni/design-system';
 import { Util } from 'src/helpers/Util';
 
 export class Comment extends Component {
@@ -44,24 +44,14 @@ export class Comment extends Component {
     if (isComplexMediaConcept) {
       return '';
     }
-    const { showCommentSection, comment } = this.state;
-    const hasNote = comment.trim().length > 0;
+    const { showCommentSection } = this.state;
     return (
-      <button
-        className={[
-          'form-builder-comment-toggle',
-          'form-builder-comment-button-toggle',
-          showCommentSection ? 'active' : '',
-          hasNote ? 'has-notes' : '',
-        ].filter(Boolean).join(' ')}
-        onClick={() => this.setState({ showCommentSection: !showCommentSection })}
-      >
-        <i className="fa fa-file-o">
-          <i className="fa fa-plus-circle" />
-          <i className="fa fa-minus-circle" />
-        </i>
-        <i className="fa fa-file-text-o" />
-      </button>
+      <SelectableTag
+        size="lg"
+        text="Note"
+        selected={showCommentSection}
+        onChange={() => this.setState({ showCommentSection: !showCommentSection })}
+      />
     );
   }
 

--- a/src/components/bahmni-design-system/Date.jsx
+++ b/src/components/bahmni-design-system/Date.jsx
@@ -4,14 +4,14 @@ import { DatePicker, DatePickerInput } from '@bahmni/design-system';
 import { Validator } from 'src/helpers/Validator';
 import isEmpty from 'lodash/isEmpty';
 import isEqual from 'lodash/isEqual';
-import classNames from 'classnames';
+import constants from 'src/constants';
 
 export class Date extends Component {
   constructor(props) {
     super(props);
     const errors = this._getErrors(props.value) || [];
     const hasErrors = this._shouldValidateOnMount() ? this._hasErrors(errors) : false;
-    this.state = { hasErrors };
+    this.state = { hasErrors, hasWarnings: false };
     this.datePickerRef = null;
   }
 
@@ -25,8 +25,10 @@ export class Date extends Component {
   shouldComponentUpdate(nextProps, nextState) {
     this.isValueChanged = this.props.value !== nextProps.value;
     if (this.props.enabled !== nextProps.enabled ||
+        this.props.validate !== nextProps.validate ||
         this.isValueChanged ||
-        this.state.hasErrors !== nextState.hasErrors) {
+        this.state.hasErrors !== nextState.hasErrors ||
+        this.state.hasWarnings !== nextState.hasWarnings) {
       return true;
     }
     return false;
@@ -37,17 +39,15 @@ export class Date extends Component {
         !isEqual(this.props.value, prevProps.value)) {
       const errors = this._getErrors(this.props.value);
       const hasErrors = this._hasErrors(errors);
+      const hasWarnings = this._hasWarnings(errors);
 
-      if (this.state.hasErrors !== hasErrors) {
-        this.setState({ hasErrors });
+      if (this.state.hasErrors !== hasErrors || this.state.hasWarnings !== hasWarnings) {
+        this.setState({ hasErrors, hasWarnings });
       }
     }
 
-    const errors = this._getErrors(this.props.value);
-    if (this._hasErrors(errors)) {
-      this.props.onChange({ value: this.props.value, errors });
-    }
     if (this.isValueChanged) {
+      const errors = this._getErrors(this.props.value);
       this.props.onChange({ value: this.props.value, errors });
     }
   }
@@ -58,7 +58,7 @@ export class Date extends Component {
       if (!dates || !Array.isArray(dates) || dates.length === 0) {
         const value = undefined;
         const errors = this._getErrors(value);
-        this.setState({ hasErrors: this._hasErrors(errors) });
+        this.setState({ hasErrors: this._hasErrors(errors), hasWarnings: this._hasWarnings(errors) });
         this.props.onChange({ value, errors });
         return;
       }
@@ -67,14 +67,14 @@ export class Date extends Component {
       if (!selectedDate) {
         const value = undefined;
         const errors = this._getErrors(value);
-        this.setState({ hasErrors: this._hasErrors(errors) });
+        this.setState({ hasErrors: this._hasErrors(errors), hasWarnings: this._hasWarnings(errors) });
         this.props.onChange({ value, errors });
         return;
       }
 
       const value = this._formatDate(selectedDate);
       const errors = this._getErrors(value);
-      this.setState({ hasErrors: this._hasErrors(errors) });
+      this.setState({ hasErrors: this._hasErrors(errors), hasWarnings: this._hasWarnings(errors) });
       this.props.onChange({ value, errors });
     } catch (error) {
       console.error('Error in handleChange:', error);
@@ -106,7 +106,11 @@ export class Date extends Component {
   }
 
   _hasErrors(errors) {
-    return !isEmpty(errors);
+    return !isEmpty(errors.filter(e => e.type !== constants.errorTypes.warning));
+  }
+
+  _hasWarnings(errors) {
+    return !isEmpty(errors.filter(e => e.type === constants.errorTypes.warning));
   }
 
   _getErrors(value) {
@@ -117,30 +121,25 @@ export class Date extends Component {
 
   render() {
     const { conceptUuid, label, enabled } = this.props;
-    const displayHasErrors = this.state.hasErrors;
 
     return (
-      <div className={classNames({
-        'form-builder-error': displayHasErrors,
-        'form-builder-warning': false
-      })}>
-        <DatePicker
-          datePickerType="single"
-          dateFormat="Y-m-d"
-          value={this.props.value}
-          onChange={(dates) => this.handleChange(dates)}
-          ref={(ref) => { this.datePickerRef = ref; }}
-        >
-          <DatePickerInput
-            id={conceptUuid}
-            labelText={label}
-            placeholder="yyyy-mm-dd"
-            size="sm"
-            disabled={!enabled}
-            invalid={displayHasErrors}
-          />
-        </DatePicker>
-      </div>
+      <DatePicker
+        datePickerType="single"
+        dateFormat="Y-m-d"
+        value={this.props.value}
+        onChange={(dates) => this.handleChange(dates)}
+        ref={(ref) => { this.datePickerRef = ref; }}
+      >
+        <DatePickerInput
+          id={conceptUuid}
+          labelText={label}
+          placeholder="yyyy-mm-dd"
+          size="sm"
+          disabled={!enabled}
+          invalid={this.state.hasErrors}
+          warn={this.state.hasWarnings}
+        />
+      </DatePicker>
     );
   }
 }

--- a/src/components/bahmni-design-system/DateTime.jsx
+++ b/src/components/bahmni-design-system/DateTime.jsx
@@ -34,6 +34,7 @@ export class DateTime extends Component {
   shouldComponentUpdate(nextProps, nextState) {
     const valueChanged = this.props.value !== nextProps.value;
     if (this.props.enabled !== nextProps.enabled ||
+        this.props.validate !== nextProps.validate ||
         valueChanged ||
         !isEqual(this.state, nextState)) {
       return true;
@@ -59,10 +60,6 @@ export class DateTime extends Component {
       }
     }
 
-    const errors = this._getAllErrors(dateValue, timeValue);
-    if (this._hasErrors(errors)) {
-      this.props.onChange({ value: this.props.value, errors });
-    }
   }
 
   _parseValue(value) {

--- a/src/components/bahmni-design-system/DropDown.jsx
+++ b/src/components/bahmni-design-system/DropDown.jsx
@@ -27,7 +27,8 @@ export class DropDown extends Component {
     return (
       this.isValueChanged ||
       this.state.hasErrors !== nextState.hasErrors ||
-      this.props.enabled !== nextProps.enabled
+      this.props.enabled !== nextProps.enabled ||
+      this.props.validate !== nextProps.validate
     );
   }
 
@@ -41,13 +42,6 @@ export class DropDown extends Component {
       }
     }
 
-    const errors = this._getErrors(this.props.value);
-    if (this._hasErrors(errors)) {
-      this.props.onValueChange(this.props.value, errors);
-    }
-    if (this.isValueChanged) {
-      this.props.onValueChange(this.props.value, errors);
-    }
   }
 
   _hasErrors(errors) {
@@ -60,10 +54,6 @@ export class DropDown extends Component {
 
   _isCreateByAddMore() {
     return !!this.props.formFieldPath && this.props.formFieldPath.split('-')[1] !== '0';
-  }
-
-  _getInvalidText(errors) {
-    return errors && errors.length > 0 ? errors[0].message : '';
   }
 
   handleChange({ selectedItem }) {
@@ -80,14 +70,12 @@ export class DropDown extends Component {
 
   render() {
     const { conceptUuid, enabled, multiSelect, options, value } = this.props;
-    const errors = this._getErrors(value);
     if (multiSelect) {
       return (
         <FilterableMultiSelect
           id={conceptUuid || 'dropdown'}
           disabled={!enabled}
           invalid={this.state.hasErrors}
-          invalidText={this._getInvalidText(errors)}
           items={options}
           itemToString={(item) => item?.name || ''}
           placeholder=""
@@ -102,7 +90,6 @@ export class DropDown extends Component {
         id={conceptUuid || 'dropdown'}
         disabled={!enabled}
         invalid={this.state.hasErrors}
-        invalidText={this._getInvalidText(errors)}
         items={options}
         itemToString={(item) => item?.name || ''}
         label=""

--- a/src/components/bahmni-design-system/DropDown.jsx
+++ b/src/components/bahmni-design-system/DropDown.jsx
@@ -42,6 +42,10 @@ export class DropDown extends Component {
       }
     }
 
+    if (this.isValueChanged) {
+      const errors = this._getErrors(this.props.value);
+      this.props.onValueChange(this.props.value, errors);
+    }
   }
 
   _hasErrors(errors) {

--- a/src/components/bahmni-design-system/FreeTextAutoComplete.jsx
+++ b/src/components/bahmni-design-system/FreeTextAutoComplete.jsx
@@ -27,7 +27,8 @@ export class FreeTextAutoComplete extends Component {
       this.isValueChanged ||
       this.state.hasErrors !== nextState.hasErrors ||
       !isEqual(this.state.value, nextState.value) ||
-      this.props.enabled !== nextProps.enabled
+      this.props.enabled !== nextProps.enabled ||
+      this.props.validate !== nextProps.validate
     );
   }
 
@@ -45,11 +46,8 @@ export class FreeTextAutoComplete extends Component {
       }
     }
 
-    const errors = this._getErrors(this.props.value);
-    if (this._hasErrors(errors)) {
-      this.props.onChange({ value: this.props.value, errors });
-    }
     if (this.isValueChanged) {
+      const errors = this._getErrors(this.props.value);
       this.props.onChange({ value: this.props.value, errors });
     }
   }
@@ -66,10 +64,6 @@ export class FreeTextAutoComplete extends Component {
     return !!this.props.formFieldPath && this.props.formFieldPath.split('-')[1] !== '0';
   }
 
-  _getInvalidText(errors) {
-    return errors && errors.length > 0 ? errors[0].message : '';
-  }
-
   handleChange({ selectedItem, inputValue }) {
     // selectedItem is null for custom-typed values; use inputValue in that case
     const value = selectedItem !== null && selectedItem !== undefined
@@ -82,14 +76,12 @@ export class FreeTextAutoComplete extends Component {
 
   render() {
     const { conceptUuid, enabled, options } = this.props;
-    const errors = this._getErrors(this.props.value);
     return (
       <ComboBox
         id={conceptUuid || 'free-text-autocomplete'}
         allowCustomValue
         disabled={!enabled}
         invalid={this.state.hasErrors}
-        invalidText={this._getInvalidText(errors)}
         items={options}
         itemToString={(item) => (typeof item === 'string' ? item
           : item?.label || item?.name?.display || item?.name || '')}

--- a/src/components/bahmni-design-system/NumericBox.jsx
+++ b/src/components/bahmni-design-system/NumericBox.jsx
@@ -50,19 +50,15 @@ export const NumericBox = ({
   useEffect(() => {
     if (isInitialized) return;
 
-    // Don't show errors on mount - only show them after user interaction or form validation
     setHasErrors(false);
     setHasWarnings(false);
 
-    // Call onChange on mount with the value if it exists
-    if (typeof value !== 'undefined' || validateForm) {
-      onChange({
-        value,
-        errors: [],
-        triggerControlEvent: false,
-        calledOnMount: true,
-      });
-    }
+    onChange({
+      value,
+      errors: _getErrors(value),
+      triggerControlEvent: false,
+      calledOnMount: true,
+    });
 
     setIsInitialized(true);
   }, []);
@@ -142,19 +138,21 @@ export const NumericBox = ({
   // Ensure value is always numeric (never string) for Carbon NumberInput.toFixed() compatibility
   const getNumericValue = () => {
     if (value === null || value === undefined || value === '') {
-      return 0;
+      return '';
     }
     const num = parseFloat(value);
-    return isNaN(num) ? 0 : num;
+    return isNaN(num) ? '' : num;
   };
 
   return (
     <div className="obs-numeric-text-wrap">
       <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
         <NumberInput
+          allowEmpty
           value={getNumericValue()}
           onChange={handleChange}
           invalid={hasErrors}
+          warn={hasWarnings}
           disabled={!enabled}
           step={1}
           {...props}

--- a/src/components/bahmni-design-system/NumericBox.jsx
+++ b/src/components/bahmni-design-system/NumericBox.jsx
@@ -146,7 +146,7 @@ export const NumericBox = ({
 
   return (
     <div className="obs-numeric-text-wrap">
-      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--cds-spacing-03)' }}>
         <NumberInput
           allowEmpty
           value={getNumericValue()}

--- a/src/components/bahmni-design-system/NumericBox.jsx
+++ b/src/components/bahmni-design-system/NumericBox.jsx
@@ -53,12 +53,14 @@ export const NumericBox = ({
     setHasErrors(false);
     setHasWarnings(false);
 
-    onChange({
-      value,
-      errors: _getErrors(value),
-      triggerControlEvent: false,
-      calledOnMount: true,
-    });
+    if (typeof value !== 'undefined' || validateForm) {
+      onChange({
+        value,
+        errors: [],
+        triggerControlEvent: false,
+        calledOnMount: true,
+      });
+    }
 
     setIsInitialized(true);
   }, []);

--- a/src/components/bahmni-design-system/ObsControl.jsx
+++ b/src/components/bahmni-design-system/ObsControl.jsx
@@ -1,0 +1,297 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { SelectableTag } from '@bahmni/design-system';
+import { Label } from 'components/Label.jsx';
+import ComponentStore from 'src/helpers/componentStore';
+import find from 'lodash/find';
+import { Comment } from 'components/Comment.jsx';
+import { getValidations } from 'src/helpers/controlsHelper';
+import { UnSupportedComponent } from 'components/UnSupportedComponent.jsx';
+import constants from 'src/constants';
+import { Util } from 'src/helpers/Util';
+import { injectIntl } from 'react-intl';
+import addMoreDecorator from '../AddMoreDecorator';
+
+export class ObsControl extends addMoreDecorator(Component) {
+
+  constructor(props) {
+    super(props);
+    this.state = {};
+    this.onChange = this.onChange.bind(this);
+    this.onCommentChange = this.onCommentChange.bind(this);
+    this.onAddControl = this.onAddControl.bind(this);
+    this.onRemoveControl = this.onRemoveControl.bind(this);
+    this.onValueChangeDone = this.onValueChangeDone.bind(this);
+    this.setAbnormal = this.setAbnormal.bind(this);
+  }
+
+  isAllowedToTriggerControlEvent(triggerControlEvent) {
+    return triggerControlEvent === undefined || triggerControlEvent;
+  }
+
+  onValueChangeDone(triggerControlEvent) {
+    if (this.props.onEventTrigger && this.isAllowedToTriggerControlEvent(triggerControlEvent)) {
+      this.props.onEventTrigger(this.props.formFieldPath, 'onValueChange');
+    }
+  }
+
+  onChange({ value, errors, calledOnMount, triggerControlEvent }) {
+    const { metadata: { properties } } = this.props;
+    const isAbnormalPropertyEnabled = find(properties, (val, key) => (key === 'abnormal' && val));
+    const isAbnormal = find(errors, (err) => err.type === constants.errorTypes.warning
+                                              && err.message === constants.validations.allowRange);
+    let interpretation = isAbnormalPropertyEnabled && isAbnormal ? 'ABNORMAL' : null;
+    if (calledOnMount) {
+      interpretation = this.props.value.interpretation;
+    }
+    const obsValue = { value, comment: this.props.value.comment, interpretation };
+    this.setState({
+      errors,
+    });
+    this.props.onValueChanged(
+      this.props.formFieldPath,
+      obsValue,
+      errors,
+       () => this.onValueChangeDone(triggerControlEvent));
+  }
+
+  onCommentChange(comment) {
+    this.props.onValueChanged(
+      this.props.formFieldPath,
+      { value: this.props.value.value, comment, interpretation: this.props.value.interpretation },
+      undefined
+    );
+  }
+
+  displayObsControl(registeredComponent) {
+    const { onControlAdd, hidden, enabled, metadata,
+      metadata: { concept }, validate, validateForm, formFieldPath,
+      showNotification, intl } = this.props;
+    const options = metadata.options || concept.answers;
+    const { conceptClass, conceptHandler } = concept;
+    const validations = getValidations(metadata.properties, concept.properties);
+    const isAddMoreEnabled =
+      find(metadata.properties, (value, key) => (key === 'addMore' && value));
+    return React.createElement(registeredComponent, {
+      hidden,
+      enabled,
+      properties: metadata.properties,
+      options,
+      onChange: this.onChange,
+      onControlAdd,
+      onEventTrigger: this.onEventTrigger,
+      validate,
+      validateForm,
+      formFieldPath,
+      patientUuid: this.props.patientUuid,
+      conceptUuid: this.props.metadata.concept.uuid,
+      addMore: isAddMoreEnabled,
+      validations,
+      value: this.props.value.value,
+      ...this._numericContext(metadata),
+      showNotification,
+      conceptClass,
+      conceptHandler,
+      intl,
+      componentStore: this.props.componentStore || ComponentStore,
+    });
+  }
+
+  _numericContext(metadata) {
+    return {
+      hiNormal: metadata.hiNormal,
+      lowNormal: metadata.lowNormal,
+      hiAbsolute: metadata.hiAbsolute,
+      lowAbsolute: metadata.lowAbsolute,
+    };
+  }
+
+  _getUnits(units) {
+    return units ? `(${units})` : '';
+  }
+
+  displayLabel() {
+    const { enabled, intl, hidden, metadata: { properties, label, units, concept } } = this.props;
+    const { concept: { description } } = this.props.metadata;
+    const hideLabel = find(properties, (value, key) => (key === 'hideLabel' && value));
+    const labelMetadata = { ...label, ...concept, units: this._getUnits(units) };
+    const showHintButton = this.state && this.state.showHintButton;
+    const labelComponent = (<Label enabled={enabled} hidden={hidden}
+      intl={intl} metadata={labelMetadata}
+    />);
+    return (
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 'var(--cds-spacing-02)' }}>
+        {!hideLabel && labelComponent}
+        {!hideLabel && this.markMandatory()}
+        {!hideLabel && description && description.value &&
+        <i className="fa fa-question-circle form-builder-tooltip-trigger"
+          onClick={() => this.setState({ showHintButton: !showHintButton })}
+        />}
+      </div>
+    );
+  }
+
+  markMandatory() {
+    const { properties } = this.props.metadata;
+    const isMandatory = find(properties, (value, key) => (key === 'mandatory' && value));
+    if (isMandatory) {
+      return <span className="form-builder-asterisk">*</span>;
+    }
+    return null;
+  }
+
+  showHelperText() {
+    const { concept: { description } } = this.props.metadata;
+    if (description && description.value) {
+      const showHelperTextHtml = this.props.intl.formatHTMLMessage({
+        defaultMessage: description.value,
+        id: description.translationKey || 'defaultId',
+      });
+      return (
+          <div className={classNames('form-builder-tooltip-wrap',
+              { active: this.state.showHintButton === true })}>
+          <p className="form-builder-tooltip-description">
+            <i className="fa fa-caret-down"></i>
+            <span className="details hint" dangerouslySetInnerHTML={{ __html: showHelperTextHtml }}>
+            </span>
+          </p>
+        </div>
+      );
+    }
+    return null;
+  }
+
+  showComment() {
+    const { metadata: { properties } } = this.props;
+    const isAddCommentsEnabled = find(properties, (value, key) => (key === 'notes' && value));
+    if (isAddCommentsEnabled) {
+      const comment = this.props.value.comment;
+      const value = this.props.value.value;
+      const { concept } = this.props.metadata;
+      return (
+        <Comment
+          comment={comment} conceptHandler={concept.conceptHandler}
+          datatype={concept.datatype} onCommentChange={this.onCommentChange}
+          value={value}
+        />
+      );
+    }
+    return null;
+  }
+
+  isCreateByAddMore() {
+    return (this.props.formFieldPath.split('-')[1] !== '0');
+  }
+
+  showAbnormalButton() {
+    const { metadata: { properties }, value } = this.props;
+    const isAbnormal = find(properties, (val, key) => (key === 'abnormal' && val));
+    const isAbnormalObs = (value.interpretation === 'ABNORMAL');
+    if (isAbnormal) {
+      return (
+        <SelectableTag
+          size="lg"
+          text="Abnormal"
+          selected={isAbnormalObs}
+          disabled={!value.value}
+          onChange={this.setAbnormal}
+        />
+      );
+    }
+    return null;
+  }
+
+  setAbnormal() {
+    const { value, onValueChanged, formFieldPath } = this.props;
+    const { errors } = this.state;
+    if (value.value) {
+      const interpretation = value.interpretation === 'ABNORMAL' ? null : 'ABNORMAL';
+      if (!errors || errors.length === 0) {
+        onValueChanged(
+          formFieldPath,
+          { value: this.props.value.value, comment: this.props.value.comment, interpretation },
+          undefined
+        );
+      } else {
+        const hasCriticalError = errors.some(error => error.type === 'error');
+        onValueChanged(
+          formFieldPath,
+          { value: this.props.value.value, comment: this.props.value.comment, interpretation },
+          hasCriticalError ? errors : undefined
+        );
+      }
+    }
+  }
+
+  render() {
+    const { concept } = this.props.metadata;
+    const store = this.props.componentStore || ComponentStore;
+    const registeredComponent = store.getRegisteredComponent(concept.datatype);
+    const complexClass = Util.isComplexMediaConcept(concept) ? 'complex-component' : '';
+    const addMoreComplexClass = complexClass && this.isCreateByAddMore() ?
+        'add-more-complex-component' : '';
+    if (registeredComponent) {
+      return (
+          <div className={classNames('form-field-wrap clearfix', `${complexClass}`)}>
+              {this.showHelperText()}
+              <div className="form-field-content-wrap">
+                  <div className={classNames('label-wrap fl', `${addMoreComplexClass}`)}>
+                      {this.displayLabel()}
+                  </div>
+                  <div className={classNames('obs-control-field')}>
+                      {this.displayObsControl(registeredComponent)}
+                      {this.showAbnormalButton()}
+                      {this.showAddMore()}
+                      {this.showComment()}
+                  </div>
+              </div>
+          </div>
+      );
+    }
+    return (
+        <div>
+          <UnSupportedComponent
+            message={ `The component with concept datatype ${concept.datatype} is not supported` }
+          />
+        </div>
+    );
+  }
+}
+
+ObsControl.propTypes = {
+  children: PropTypes.array,
+  collapse: PropTypes.bool,
+  enabled: PropTypes.bool,
+  metadata: PropTypes.shape({
+    concept: PropTypes.object.isRequired,
+    displayType: PropTypes.string,
+    id: PropTypes.string.isRequired,
+    label: PropTypes.shape({
+      type: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired,
+    }).isRequired,
+    properties: PropTypes.object,
+    type: PropTypes.string.isRequired,
+  }),
+  onControlAdd: PropTypes.func,
+  onControlRemove: PropTypes.func,
+  onValueChanged: PropTypes.func.isRequired,
+  showAddMore: PropTypes.bool.isRequired,
+  showNotification: PropTypes.func.isRequired,
+  showRemove: PropTypes.bool.isRequired,
+  validate: PropTypes.bool.isRequired,
+  validateForm: PropTypes.bool.isRequired,
+  value: PropTypes.object.isRequired,
+};
+
+ObsControl.defaultProps = {
+  enabled: true,
+  hidden: false,
+  showAddMore: false,
+  showRemove: false,
+};
+
+const ObsControlWithIntl = injectIntl(ObsControl, { forwardRef: true });
+
+export { ObsControlWithIntl };

--- a/src/components/bahmni-design-system/ObsControl.jsx
+++ b/src/components/bahmni-design-system/ObsControl.jsx
@@ -5,7 +5,7 @@ import { SelectableTag } from '@bahmni/design-system';
 import { Label } from 'components/Label.jsx';
 import ComponentStore from 'src/helpers/componentStore';
 import find from 'lodash/find';
-import { Comment } from 'components/Comment.jsx';
+import { Comment } from 'components/bahmni-design-system/Comment.jsx';
 import { getValidations } from 'src/helpers/controlsHelper';
 import { UnSupportedComponent } from 'components/UnSupportedComponent.jsx';
 import constants from 'src/constants';

--- a/src/components/bahmni-design-system/TextBox.jsx
+++ b/src/components/bahmni-design-system/TextBox.jsx
@@ -4,13 +4,14 @@ import { Validator } from 'src/helpers/Validator';
 import isEmpty from 'lodash/isEmpty';
 import { TextArea } from '@bahmni/design-system';
 import isEqual from 'lodash/isEqual';
+import constants from 'src/constants';
 
 export class TextBox extends Component {
   constructor(props) {
     super(props);
     const errors = this._getErrors(props.value) || [];
     const hasErrors = this._isCreateByAddMore() ? this._hasErrors(errors) : false;
-    this.state = { hasErrors };
+    this.state = { hasErrors, hasWarnings: false };
   }
 
   componentDidMount() {
@@ -23,8 +24,10 @@ export class TextBox extends Component {
   shouldComponentUpdate(nextProps, nextState) {
     this.isValueChanged = this.props.value !== nextProps.value;
     if (this.props.enabled !== nextProps.enabled ||
+      this.props.validate !== nextProps.validate ||
       this.isValueChanged ||
-      this.state.hasErrors !== nextState.hasErrors) {
+      this.state.hasErrors !== nextState.hasErrors ||
+      this.state.hasWarnings !== nextState.hasWarnings) {
       return true;
     }
     return false;
@@ -35,22 +38,24 @@ export class TextBox extends Component {
         !isEqual(this.props.value, prevProps.value)) {
       const errors = this._getErrors(this.props.value);
       const hasErrors = this._hasErrors(errors);
-      if (this.state.hasErrors !== hasErrors) {
-        this.setState({ hasErrors });
+      const hasWarnings = this._hasWarnings(errors);
+      if (this.state.hasErrors !== hasErrors || this.state.hasWarnings !== hasWarnings) {
+        this.setState({ hasErrors, hasWarnings });
       }
     }
 
-    const errors = this._getErrors(this.props.value);
-    if (this._hasErrors(errors)) {
-      this.props.onChange({ value: this.props.value, errors });
-    }
     if (this.isValueChanged) {
+      const errors = this._getErrors(this.props.value);
       this.props.onChange({ value: this.props.value, errors });
     }
   }
 
   _hasErrors(errors) {
-    return !isEmpty(errors);
+    return !isEmpty(errors.filter(e => e.type !== constants.errorTypes.warning));
+  }
+
+  _hasWarnings(errors) {
+    return !isEmpty(errors.filter(e => e.type === constants.errorTypes.warning));
   }
 
   _getErrors(value) {
@@ -66,7 +71,7 @@ export class TextBox extends Component {
   handleChange(e) {
     const value = e.target.value;
     const errors = this._getErrors(value);
-    this.setState({ hasErrors: this._hasErrors(errors) });
+    this.setState({ hasErrors: this._hasErrors(errors), hasWarnings: this._hasWarnings(errors) });
     this.props.onChange({ value, errors });
   }
 
@@ -78,6 +83,7 @@ export class TextBox extends Component {
           disabled={!this.props.enabled}
           id={this.props.conceptUuid}
           invalid={this.state.hasErrors}
+          warn={this.state.hasWarnings}
           labelText=""
           onChange={(e) => this.handleChange(e)}
           rows={3}

--- a/styles/bahmniAppsFormBuilder/_form.scss
+++ b/styles/bahmniAppsFormBuilder/_form.scss
@@ -13,6 +13,7 @@ $lightestGray: #eee;
     padding-top: 5px;
     box-sizing: border-box;
     clear: both;
+    overflow-wrap: break-word;
 
     .form-builder-column {
       min-height: 50px;
@@ -113,6 +114,10 @@ $lightestGray: #eee;
             .cds--number__controls,
             .cds--number__control-btn {
               height: 100% !important;
+            }
+
+            .cds--form-requirement {
+              display: none;
             }
 
             .obs-numeric-range {

--- a/styles/bahmniAppsFormBuilder/_form.scss
+++ b/styles/bahmniAppsFormBuilder/_form.scss
@@ -116,6 +116,10 @@ $lightestGray: #eee;
               height: 100% !important;
             }
 
+            // Hide Carbon's inline error/warning text — validation messages are
+            // rendered via the custom .form-builder-error/.form-builder-warning
+            // styles on the input. Scoped to .obs-numeric-text-wrap so it only
+            // affects NumericBox, not other Carbon components on the form.
             .cds--form-requirement {
               display: none;
             }

--- a/test/components/Container.test.js
+++ b/test/components/Container.test.js
@@ -581,6 +581,24 @@ describe('Container', () => {
 
       expect(screen.getByText(/pulse.*\/min/i)).toBeInTheDocument();
     });
+
+    it('should fallback to original text when translation key equals its value (untranslated entry)', () => {
+      const metadata = createNumericControlMetadata({
+        controls: [{
+          ...createNumericControlMetadata().controls[0],
+          label: { type: 'label', value: 'Pulse(/min)', translationKey: 'PULSE_LABEL' },
+        }],
+      });
+      const translations = {
+        labels: { PULSE_LABEL: 'PULSE_LABEL' },
+        concepts: {},
+      };
+
+      renderContainer({ metadata, translations });
+
+      expect(screen.queryByText(/PULSE_LABEL/)).not.toBeInTheDocument();
+      expect(screen.getByText(/Pulse/)).toBeInTheDocument();
+    });
   });
 
   describe('Coverage Improvements', () => {

--- a/test/components/bahmni-design-system/AutoComplete.test.js
+++ b/test/components/bahmni-design-system/AutoComplete.test.js
@@ -880,7 +880,7 @@ describe('Carbon AutoComplete', () => {
   describe('Edge cases', () => {
     it('should handle validateForm changing to true', () => {
       const validations = [constants.validations.mandatory];
-      const { rerender } = render(
+      const { rerender, container } = render(
         <AutoComplete
           asynchronous={false}
           formFieldPath="test/1-0"
@@ -904,6 +904,7 @@ describe('Carbon AutoComplete', () => {
         />
       );
 
+      expect(container.querySelector('.form-builder-error')).toBeTruthy();
       expect(mockOnValueChange).toHaveBeenCalledWith(
         undefined,
         expect.arrayContaining([

--- a/test/components/bahmni-design-system/AutoComplete.test.js
+++ b/test/components/bahmni-design-system/AutoComplete.test.js
@@ -905,12 +905,7 @@ describe('Carbon AutoComplete', () => {
       );
 
       expect(container.querySelector('.form-builder-error')).toBeTruthy();
-      expect(mockOnValueChange).toHaveBeenCalledWith(
-        undefined,
-        expect.arrayContaining([
-          expect.objectContaining({ message: constants.validations.mandatory }),
-        ])
-      );
+      expect(mockOnValueChange).not.toHaveBeenCalled();
     });
 
     it('should have obs-control-select-wrapper as the outer div class', () => {

--- a/test/components/bahmni-design-system/CarbonContainer.test.js
+++ b/test/components/bahmni-design-system/CarbonContainer.test.js
@@ -216,4 +216,28 @@ describe('CarbonContainer', () => {
     expect(ref.current).toBeTruthy();
     expect(typeof ref.current.getValue).toBe('function');
   });
+
+  it('should render the Carbon ObsControl (with SelectableTag abnormal button) for obsControl type', () => {
+    const abnormalMetadata = {
+      controls: [{
+        concept: { answers: [], datatype: 'Numeric', description: [],
+          name: 'Pulse', properties: { allowDecimal: true }, uuid: 'pulse-uuid' },
+        id: '1', label: { type: 'label', value: 'Pulse' },
+        properties: { addMore: false, hideLabel: false, location: { column: 0, row: 0 },
+          mandatory: false, notes: false, abnormal: true },
+        type: 'obsControl', hiAbsolute: null, hiNormal: 100, lowAbsolute: null, lowNormal: 60,
+      }],
+      id: 10, name: 'AbnormalForm', uuid: 'form-uuid-10', version: '1', defaultLocale: 'en',
+    };
+    const observations = [{
+      concept: { uuid: 'pulse-uuid' },
+      formFieldPath: 'AbnormalForm.1/1-0',
+      value: 120,
+      voided: false,
+    }];
+
+    render(<CarbonContainer {...defaultProps} metadata={abnormalMetadata} observations={observations} />);
+
+    expect(screen.getByText('Abnormal')).toBeInTheDocument();
+  });
 });

--- a/test/components/bahmni-design-system/Comment.test.js
+++ b/test/components/bahmni-design-system/Comment.test.js
@@ -1,0 +1,133 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Comment } from 'components/bahmni-design-system/Comment.jsx';
+import { Util } from 'helpers/Util';
+
+jest.mock('src/helpers/Util', () => ({
+  Util: {
+    isComplexMediaConcept: jest.fn(),
+  },
+}));
+
+describe('Carbon Comment', () => {
+  let mockOnCommentChange;
+
+  beforeEach(() => {
+    mockOnCommentChange = jest.fn();
+    Util.isComplexMediaConcept.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render add comment button', () => {
+    render(<Comment onCommentChange={mockOnCommentChange} />);
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('should render the comment section on click of button', () => {
+    render(<Comment onCommentChange={mockOnCommentChange} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('should hide the comment section on click of button if it is shown', () => {
+    render(<Comment onCommentChange={mockOnCommentChange} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('should set comment', () => {
+    render(<Comment onCommentChange={mockOnCommentChange} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'New Comment' } });
+
+    expect(mockOnCommentChange).toHaveBeenCalledWith('New Comment');
+  });
+
+  it('should call onCommentChange with undefined if filled with empty spaces', () => {
+    render(<Comment onCommentChange={mockOnCommentChange} />);
+
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: '   ' } });
+
+    expect(mockOnCommentChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should render comment section with default value', () => {
+    render(<Comment comment="Some Comment" onCommentChange={mockOnCommentChange} />);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(screen.getByRole('textbox')).toHaveValue('Some Comment');
+  });
+
+  it('should not render comment button when the control is of complex media type', () => {
+    Util.isComplexMediaConcept.mockReturnValue(true);
+
+    render(
+      <Comment
+        conceptHandler="ImageUrlHandler"
+        datatype="Complex"
+        onCommentChange={mockOnCommentChange}
+      />
+    );
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('should render comment button when the control is of complex but not media type', () => {
+    Util.isComplexMediaConcept.mockReturnValue(false);
+
+    render(
+      <Comment
+        conceptHandler="LocationHandler"
+        datatype="Complex"
+        onCommentChange={mockOnCommentChange}
+      />
+    );
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('should render comment section when the complex media type control has value', () => {
+    Util.isComplexMediaConcept.mockReturnValue(true);
+
+    render(
+      <Comment
+        conceptHandler="ImageUrlHandler"
+        datatype="Complex"
+        onCommentChange={mockOnCommentChange}
+        value="someValue"
+      />
+    );
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('should not render comment section when the complex media control does not have value', () => {
+    Util.isComplexMediaConcept.mockReturnValue(true);
+
+    render(
+      <Comment
+        conceptHandler="ImageUrlHandler"
+        datatype="Complex"
+        onCommentChange={mockOnCommentChange}
+        value={undefined}
+      />
+    );
+
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+});

--- a/test/components/bahmni-design-system/Date.test.js
+++ b/test/components/bahmni-design-system/Date.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { Date } from '../../../src/components/bahmni-design-system/Date';
+import constants from 'src/constants';
 
 describe('Date', () => {
   const mockOnChange = jest.fn();
@@ -98,5 +99,59 @@ describe('Date', () => {
         triggerControlEvent: false,
       })
     );
+  });
+
+  test('should show invalid state when validate changes to true with mandatory field and no value', () => {
+    const validations = [constants.validations.mandatory];
+    const { rerender } = render(
+      <Date
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        validate={false}
+        validateForm={false}
+        validations={validations}
+      />
+    );
+
+    mockOnChange.mockClear();
+
+    rerender(
+      <Date
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        validate={true}
+        validateForm={false}
+        validations={validations}
+      />
+    );
+
+    expect(document.querySelector('[data-invalid]')).toBeTruthy();
+  });
+
+  test('should not call onChange when validate changes to true', () => {
+    const validations = [constants.validations.mandatory];
+    const { rerender } = render(
+      <Date
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        validate={false}
+        validateForm={false}
+        validations={validations}
+      />
+    );
+
+    mockOnChange.mockClear();
+
+    rerender(
+      <Date
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        validate={true}
+        validateForm={false}
+        validations={validations}
+      />
+    );
+
+    expect(mockOnChange).not.toHaveBeenCalled();
   });
 });

--- a/test/components/bahmni-design-system/DateTime.test.js
+++ b/test/components/bahmni-design-system/DateTime.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { DateTime } from '../../../src/components/bahmni-design-system/DateTime';
+import constants from 'src/constants';
 
 describe('DateTime', () => {
   const mockOnChange = jest.fn();
@@ -98,5 +99,59 @@ describe('DateTime', () => {
         triggerControlEvent: false,
       })
     );
+  });
+
+  test('should add form-builder-error class when validate changes to true with partial value (date only)', () => {
+    const { rerender, container } = render(
+      <DateTime
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        validate={false}
+        validateForm={false}
+        validations={[]}
+        value="2024-01-15"
+      />
+    );
+
+    mockOnChange.mockClear();
+
+    rerender(
+      <DateTime
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        validate={true}
+        validateForm={false}
+        validations={[]}
+        value="2024-01-15"
+      />
+    );
+
+    expect(container.querySelector('.form-builder-error')).toBeTruthy();
+  });
+
+  test('should not call onChange when validate changes to true', () => {
+    const { rerender } = render(
+      <DateTime
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        validate={false}
+        validateForm={false}
+        validations={[constants.validations.mandatory]}
+      />
+    );
+
+    mockOnChange.mockClear();
+
+    rerender(
+      <DateTime
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        validate={true}
+        validateForm={false}
+        validations={[constants.validations.mandatory]}
+      />
+    );
+
+    expect(mockOnChange).not.toHaveBeenCalled();
   });
 });

--- a/test/components/bahmni-design-system/DropDown.test.js
+++ b/test/components/bahmni-design-system/DropDown.test.js
@@ -388,4 +388,36 @@ describe('Carbon DropDown', () => {
       expect(screen.queryByText('Option B')).not.toBeInTheDocument();
     });
   });
+
+  describe('Validate prop change', () => {
+    const baseProps = {
+      formFieldPath: 'test1.1/1-0',
+      onValueChange: jest.fn(),
+      options,
+      validate: false,
+      validateForm: false,
+      validations: [constants.validations.mandatory],
+    };
+
+    it('should show invalid state when validate changes to true with mandatory field and no value', () => {
+      const { rerender } = render(<DropDown {...baseProps} />);
+
+      baseProps.onValueChange.mockClear();
+
+      rerender(<DropDown {...baseProps} validate={true} />);
+
+      expect(document.querySelector('[data-invalid]')).toBeTruthy();
+    });
+
+    it('should not call onValueChange when validate changes to true', () => {
+      const mockOnValueChange = jest.fn();
+      const { rerender } = render(<DropDown {...baseProps} onValueChange={mockOnValueChange} />);
+
+      mockOnValueChange.mockClear();
+
+      rerender(<DropDown {...baseProps} onValueChange={mockOnValueChange} validate={true} />);
+
+      expect(mockOnValueChange).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/test/components/bahmni-design-system/FreeTextAutoComplete.test.js
+++ b/test/components/bahmni-design-system/FreeTextAutoComplete.test.js
@@ -154,4 +154,62 @@ describe('Carbon FreeTextAutoComplete', () => {
 
     expect(container.querySelector('#free-text-autocomplete')).toBeInTheDocument();
   });
+
+  it('should show invalid state when validate changes to true with mandatory field and no value', () => {
+    const validations = [constants.validations.mandatory];
+    const { rerender } = render(
+      <FreeTextAutoComplete
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={validations}
+      />
+    );
+
+    mockOnChange.mockClear();
+
+    rerender(
+      <FreeTextAutoComplete
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        options={options}
+        validate={true}
+        validateForm={false}
+        validations={validations}
+      />
+    );
+
+    expect(document.querySelector('[data-invalid]')).toBeTruthy();
+  });
+
+  it('should not call onChange when validate changes to true', () => {
+    const validations = [constants.validations.mandatory];
+    const { rerender } = render(
+      <FreeTextAutoComplete
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        options={options}
+        validate={false}
+        validateForm={false}
+        validations={validations}
+      />
+    );
+
+    mockOnChange.mockClear();
+
+    rerender(
+      <FreeTextAutoComplete
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        options={options}
+        validate={true}
+        validateForm={false}
+        validations={validations}
+      />
+    );
+
+    expect(mockOnChange).not.toHaveBeenCalled();
+  });
 });

--- a/test/components/bahmni-design-system/NumericBox.test.js
+++ b/test/components/bahmni-design-system/NumericBox.test.js
@@ -88,7 +88,7 @@ describe('NumericBox', () => {
     );
   });
 
-  it('should handle null value and display as 0', () => {
+  it('should handle null value and display as empty', () => {
     const { container } = render(
       <NumericBox
         formFieldPath="test1.1/1-0"
@@ -101,11 +101,10 @@ describe('NumericBox', () => {
     );
 
     const input = container.querySelector('input[type="number"]');
-    // null value is displayed as 0 due to getNumericValue() function
-    expect(input).toHaveValue(0);
+    expect(input).toHaveValue(null);
   });
 
-  it('should display 0 as default value when undefined', () => {
+  it('should display empty when value is undefined', () => {
     const { container } = render(
       <NumericBox
         formFieldPath="test1.1/1-0"
@@ -117,8 +116,7 @@ describe('NumericBox', () => {
     );
 
     const input = container.querySelector('input[type="number"]');
-    // getNumericValue() returns 0 for undefined values (Carbon NumberInput compatibility)
-    expect(input).toHaveValue(0);
+    expect(input).toHaveValue(null);
   });
 
   it('should display normal range when both lowNormal and hiNormal are provided', () => {
@@ -402,7 +400,7 @@ describe('NumericBox', () => {
     );
 
     const input = container.querySelector('input[type="number"]');
-    expect(input).toHaveValue(0);
+    expect(input).toHaveValue(null);
   });
 
   it('should validate with custom validations', () => {

--- a/test/components/bahmni-design-system/ObsControl.test.js
+++ b/test/components/bahmni-design-system/ObsControl.test.js
@@ -1,0 +1,184 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { ObsControlWithIntl } from 'components/bahmni-design-system/ObsControl';
+import ComponentStore from 'src/helpers/componentStore';
+
+const MockInput = () => <input type="text" data-testid="mock-input" />;
+
+const defaultMetadata = {
+  concept: {
+    datatype: 'Text',
+    description: {},
+    name: 'Test',
+    uuid: 'test-uuid',
+    answers: [],
+    properties: {},
+  },
+  id: '1',
+  label: { type: 'label', value: 'Test Label', translationKey: 'TEST_LABEL' },
+  properties: {},
+  type: 'obsControl',
+};
+
+const abnormalMetadata = {
+  ...defaultMetadata,
+  properties: { abnormal: true },
+};
+
+const defaultProps = {
+  formFieldPath: 'test/1-0',
+  metadata: defaultMetadata,
+  onValueChanged: jest.fn(),
+  value: { value: undefined, comment: undefined, interpretation: null },
+  validate: false,
+  validateForm: false,
+  showNotification: jest.fn(),
+};
+
+const renderWithIntl = (component) => render(
+  <IntlProvider locale="en" messages={{}}>
+    {component}
+  </IntlProvider>
+);
+
+describe('Carbon ObsControl', () => {
+  beforeEach(() => {
+    ComponentStore.registerComponent('Text', MockInput);
+  });
+
+  afterEach(() => {
+    ComponentStore.deRegisterComponent('Text');
+    jest.clearAllMocks();
+  });
+
+  describe('Abnormal button', () => {
+    it('should not render the abnormal button when abnormal property is not set', () => {
+      renderWithIntl(
+        <ObsControlWithIntl
+          {...defaultProps}
+          value={{ value: 120, comment: undefined, interpretation: null }}
+        />
+      );
+
+      expect(screen.queryByText('Abnormal')).not.toBeInTheDocument();
+    });
+
+    it('should render Abnormal as a SelectableTag when abnormal property is enabled', () => {
+      renderWithIntl(
+        <ObsControlWithIntl
+          {...defaultProps}
+          metadata={abnormalMetadata}
+          value={{ value: 120, comment: undefined, interpretation: null }}
+        />
+      );
+
+      expect(screen.getByText('Abnormal')).toBeInTheDocument();
+    });
+
+    it('should disable the abnormal button when no value is set', () => {
+      renderWithIntl(
+        <ObsControlWithIntl
+          {...defaultProps}
+          metadata={abnormalMetadata}
+          value={{ value: undefined, comment: undefined, interpretation: null }}
+        />
+      );
+
+      const abnormalBtn = screen.getByText('Abnormal').closest('button');
+      expect(abnormalBtn).toBeDisabled();
+    });
+
+    it('should enable the abnormal button when value is set', () => {
+      renderWithIntl(
+        <ObsControlWithIntl
+          {...defaultProps}
+          metadata={abnormalMetadata}
+          value={{ value: 120, comment: undefined, interpretation: null }}
+        />
+      );
+
+      const abnormalBtn = screen.getByText('Abnormal').closest('button');
+      expect(abnormalBtn).not.toBeDisabled();
+    });
+
+    it('should show abnormal button as selected when interpretation is ABNORMAL', () => {
+      renderWithIntl(
+        <ObsControlWithIntl
+          {...defaultProps}
+          metadata={abnormalMetadata}
+          value={{ value: 120, comment: undefined, interpretation: 'ABNORMAL' }}
+        />
+      );
+
+      const abnormalBtn = screen.getByText('Abnormal').closest('button');
+      expect(abnormalBtn).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('should show abnormal button as not selected when interpretation is null', () => {
+      renderWithIntl(
+        <ObsControlWithIntl
+          {...defaultProps}
+          metadata={abnormalMetadata}
+          value={{ value: 120, comment: undefined, interpretation: null }}
+        />
+      );
+
+      const abnormalBtn = screen.getByText('Abnormal').closest('button');
+      expect(abnormalBtn).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('should call onValueChanged with ABNORMAL interpretation when clicked', () => {
+      const mockOnValueChanged = jest.fn();
+      renderWithIntl(
+        <ObsControlWithIntl
+          {...defaultProps}
+          metadata={abnormalMetadata}
+          onValueChanged={mockOnValueChanged}
+          value={{ value: 120, comment: undefined, interpretation: null }}
+        />
+      );
+
+      fireEvent.click(screen.getByText('Abnormal').closest('button'));
+      expect(mockOnValueChanged).toHaveBeenCalledWith(
+        'test/1-0',
+        { value: 120, comment: undefined, interpretation: 'ABNORMAL' },
+        undefined
+      );
+    });
+
+    it('should clear ABNORMAL interpretation when clicked again', () => {
+      const mockOnValueChanged = jest.fn();
+      renderWithIntl(
+        <ObsControlWithIntl
+          {...defaultProps}
+          metadata={abnormalMetadata}
+          onValueChanged={mockOnValueChanged}
+          value={{ value: 120, comment: undefined, interpretation: 'ABNORMAL' }}
+        />
+      );
+
+      fireEvent.click(screen.getByText('Abnormal').closest('button'));
+      expect(mockOnValueChanged).toHaveBeenCalledWith(
+        'test/1-0',
+        { value: 120, comment: undefined, interpretation: null },
+        undefined
+      );
+    });
+
+    it('should not call onValueChanged when abnormal button is clicked with no value', () => {
+      const mockOnValueChanged = jest.fn();
+      renderWithIntl(
+        <ObsControlWithIntl
+          {...defaultProps}
+          metadata={abnormalMetadata}
+          onValueChanged={mockOnValueChanged}
+          value={{ value: undefined, comment: undefined, interpretation: null }}
+        />
+      );
+
+      fireEvent.click(screen.getByText('Abnormal').closest('button'));
+      expect(mockOnValueChanged).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/components/bahmni-design-system/TextBox.test.js
+++ b/test/components/bahmni-design-system/TextBox.test.js
@@ -120,4 +120,58 @@ describe('Carbon TextBox', () => {
 
     expect(screen.getByRole('textbox')).toHaveClass('cds--text-area--invalid');
   });
+
+  it('should show invalid state when validate changes to true with mandatory field and no value', () => {
+    const validations = [constants.validations.mandatory];
+    const { rerender } = render(
+      <TextBox
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        validate={false}
+        validateForm={false}
+        validations={validations}
+      />
+    );
+
+    mockOnChange.mockClear();
+
+    rerender(
+      <TextBox
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        validate={true}
+        validateForm={false}
+        validations={validations}
+      />
+    );
+
+    expect(screen.getByRole('textbox')).toHaveClass('cds--text-area--invalid');
+  });
+
+  it('should not call onChange when validate changes to true', () => {
+    const validations = [constants.validations.mandatory];
+    const { rerender } = render(
+      <TextBox
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        validate={false}
+        validateForm={false}
+        validations={validations}
+      />
+    );
+
+    mockOnChange.mockClear();
+
+    rerender(
+      <TextBox
+        formFieldPath="test1.1/1-0"
+        onChange={mockOnChange}
+        validate={true}
+        validateForm={false}
+        validations={validations}
+      />
+    );
+
+    expect(mockOnChange).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Jira: [BAH-4642  ](https://bahmni.atlassian.net/jira/software/c/projects/BAH/boards/131?selectedIssue=BAH-4642)                                                                                                                                                        
   
  ---                                                                                                                                                                     
 ### Summary                                                                                                                                                               
                                                                                                                                                                          
  Migrates the ObsControl composite component to the Carbon Design System rendering path, covering layout, validation display, and locale support. No change to         
  value/event behaviour.                                                                                                                                                  
   
  - New ObsControl (Carbon): src/components/bahmni-design-system/ObsControl.jsx — renders label on the left of the input with correct Carbon spacing; dispatches the same 
  obs metadata payload (concept UUID, datatype, label) as before.                                                                                                       
  - Validation display: Carbon-style warn prop replaces legacy warning markup; error/warning state correctly propagated through all Carbon child components (TextBox,     
  NumericBox, DropDown, Date, DateTime, FreeTextAutoComplete, Button). onValueChange is no longer called on every validate cycle — only on actual value change.           
  - Label & abnormal button styles: Carbon-aligned styles for the label and selectable-tag (abnormal) button via _form.scss.
  - Locale fix (Container.jsx): Filters out translation entries where key === value (untranslated fallback entries), so only genuine translations are applied to labels.  
  - Tests: Added ObsControl.test.js and extended tests for all touched Carbon components.                                                                                 
                                                                                                                                                                          
  ---                                                                                                                                                                     
 ### Files changed                                                                                                                                                         
                                                                                                                                                                                                                                                                                                                           
  Carbon path only:
  - bahmni-design-system/ObsControl.jsx — new component
  - bahmni-design-system/TextBox, NumericBox, DropDown, Date, DateTime, FreeTextAutoComplete, Button — error/warning validation state                                     
  - bahmni-design-system/CarbonContainer.jsx — minor fix
                                                                                                                                                                          
  Shared (legacy + Carbon):                                                                                                                                             
  - src/components/Container.jsx — locale translation filter                                                                                                              
  - styles/bahmniAppsFormBuilder/_form.scss — overflow-wrap: break-word on .form-builder-row; Carbon-only accordion and form-requirement fixes       
                                                                                                                                                                          
  ---                                                                                                                                                                   
###  Disclaimer — Impact on legacy Bahmni
                                      
This PR contains two changes that affect the legacy rendering path:
                                                                                                                                                                          
  1. Container.jsx — Locale translation behaviour change: Translation entries where the key equals the value (untranslated fallbacks) are now filtered out before being   
  applied to form labels. Labels that previously rendered their untranslated key as the label text will now fall back to the concept name instead. If your deployment     
  relies on key-as-label fallback behaviour, this will be visible.                                                                                                        
  2. _form.scss — overflow-wrap: break-word on .form-builder-row: Long unbreakable strings in form labels or values will now wrap instead of overflow. This is a        
  visual-only fix and should not cause layout regressions in normal usage.          