### PR TITLE
BAH-4686: Extract shared Storybook mock data into stories/mockData.js

### DIFF
--- a/stories/AbnormalObsControl.stories.js
+++ b/stories/AbnormalObsControl.stories.js
@@ -1,94 +1,13 @@
+/* global componentStore */
 import React from 'react';
 import { ObsGroupControlWithIntl as ObsGroupControl } from 'src/components/ObsGroupControl.jsx';
 import { ObsGroupMapper } from 'src/mapper/ObsGroupMapper';
 import { Obs } from 'src/helpers/Obs';
-import { NumericBox } from 'src/components/NumericBox.jsx';
-import { BooleanControl } from 'src/components/BooleanControl.jsx';
-import { Button } from 'src/components/Button.jsx';
 import { List } from 'immutable';
 import StoryWrapper from './StoryWrapper';
-import { CodedControl } from 'src/components/CodedControl.jsx';
-import { AutoComplete } from 'src/components/AutoComplete.jsx';
-import { TextBox } from 'src/components/TextBox.jsx';
+import { pulseDataMetadata as metadata, registerCommonComponents } from './mockData';
 
-const metadata = {
-  type: 'ObsGroupControl',
-  concept: {
-    name: 'Pulse Data',
-    uuid: 'c36af094-3f10-11e4-adec-0800271c1b75',
-    datatype: 'N/A',
-  },
-  label: {
-    type: 'label',
-    value: 'Pulse Data',
-  },
-  properties: {
-    mandatory: false,
-    location: {
-      column: 0,
-      row: 0,
-    },
-  },
-  id: '5',
-  controls: [
-    {
-      type: 'obsControl',
-      label: {
-        type: 'label',
-        value: 'Pulse',
-      },
-      properties: {
-        mandatory: false,
-        location: {
-          column: 0,
-          row: 0,
-        },
-      },
-      id: '6',
-      concept: {
-        name: 'Pulse',
-        uuid: 'c36bc411-3f10-11e4-adec-0800271c1b75',
-        datatype: 'Numeric',
-        conceptClass: 'Misc',
-        lowNormal: 60,
-        hiNormal: 120,
-      },
-    },
-    {
-      type: 'obsControl',
-      displayType: 'Button',
-      options: [
-       { name: 'Abnormal', value: true },
-      ],
-      label: {
-        type: 'label',
-        value: 'Abnormal',
-      },
-      properties: {
-        mandatory: false,
-        location: {
-          column: 0,
-          row: 0,
-        },
-        hideLabel: true,
-      },
-      id: '7',
-      concept: {
-        name: 'Pulse Abnormal',
-        uuid: 'c36c7c98-3f10-11e4-adec-0800271c1b75',
-        datatype: 'Boolean',
-        conceptClass: 'Abnormal',
-      },
-    },
-  ],
-};
-
-componentStore.registerComponent('numeric', NumericBox);
-componentStore.registerComponent('boolean', BooleanControl);
-componentStore.registerComponent('button', Button);
-componentStore.registerComponent('Coded', CodedControl);
-componentStore.registerComponent('autoComplete', AutoComplete);
-componentStore.registerComponent('text', TextBox);
+registerCommonComponents();
 
 export default {
   title: 'Abnormal ObsControl',

--- a/stories/Forms.stories.js
+++ b/stories/Forms.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import StoryWrapper from './StoryWrapper';
 import { Container } from 'src/components/Container.jsx';
+import { systolicConcept } from './mockData';
 
 const form = {
   id: 1,
@@ -25,11 +26,7 @@ const form = {
         },
       },
       id: '1',
-      concept: {
-        name: 'Systolic',
-        uuid: 'c36e9c8b-3f10-11e4-adec-0800271c1b75',
-        datatype: 'Numeric',
-      },
+      concept: systolicConcept,
     },
     {
       type: 'obsControl',

--- a/stories/ObsControl.stories.js
+++ b/stories/ObsControl.stories.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { ObsControlWithIntl as ObsControl } from 'src/components/ObsControl.jsx';
 import StoryWrapper from './StoryWrapper';
 import '../styles/styles.scss';
+import { systolicConcept } from './mockData';
 
 const form = {
   controls: [
@@ -10,7 +11,7 @@ const form = {
       label: { id: 'systolic', type: 'label', value: 'Systolic' },
       properties: { mandatory: true, allowDecimal: false, addMore: true, location: { column: 0, row: 0 } },
       id: '1',
-      concept: { name: 'Systolic', uuid: 'c36e9c8b-3f10-11e4-adec-0800271c1b75', datatype: 'Numeric' },
+      concept: systolicConcept,
     },
     {
       type: 'obsControl',

--- a/stories/ObsGroupControl.stories.js
+++ b/stories/ObsGroupControl.stories.js
@@ -3,64 +3,13 @@ import React from 'react';
 import { ObsGroupControlWithIntl as ObsGroupControl } from 'src/components/ObsGroupControl.jsx';
 import { ObsGroupMapper } from 'src/mapper/ObsGroupMapper';
 import { Obs } from 'src/helpers/Obs';
-import { NumericBox } from 'src/components/NumericBox.jsx';
-import { BooleanControl } from 'src/components/BooleanControl.jsx';
-import { Button } from 'src/components/Button.jsx';
-import { CodedControl } from 'src/components/CodedControl.jsx';
-import { AutoComplete } from 'src/components/AutoComplete.jsx';
-import { TextBox } from 'src/components/TextBox.jsx';
 import { List } from 'immutable';
 import StoryWrapper from './StoryWrapper';
+import { pulseDataMetadata as pulseMetadata, registerCommonComponents } from './mockData';
 
-componentStore.registerComponent('numeric', NumericBox);
-componentStore.registerComponent('boolean', BooleanControl);
-componentStore.registerComponent('button', Button);
-componentStore.registerComponent('Coded', CodedControl);
-componentStore.registerComponent('autoComplete', AutoComplete);
-componentStore.registerComponent('text', TextBox);
+registerCommonComponents();
 
 // Pulse Data group — mirrors AbnormalObsControl but is the canonical ObsGroupControl story
-const pulseMetadata = {
-  type: 'ObsGroupControl',
-  concept: {
-    name: 'Pulse Data',
-    uuid: 'c36af094-3f10-11e4-adec-0800271c1b75',
-    datatype: 'N/A',
-  },
-  label: { type: 'label', value: 'Pulse Data' },
-  properties: { mandatory: false, location: { column: 0, row: 0 } },
-  id: '5',
-  controls: [
-    {
-      type: 'obsControl',
-      label: { type: 'label', value: 'Pulse' },
-      properties: { mandatory: false, location: { column: 0, row: 0 } },
-      id: '6',
-      concept: {
-        name: 'Pulse',
-        uuid: 'c36bc411-3f10-11e4-adec-0800271c1b75',
-        datatype: 'Numeric',
-        conceptClass: 'Misc',
-        lowNormal: 60,
-        hiNormal: 120,
-      },
-    },
-    {
-      type: 'obsControl',
-      displayType: 'Button',
-      options: [{ name: 'Abnormal', value: true }],
-      label: { type: 'label', value: 'Abnormal' },
-      properties: { mandatory: false, location: { column: 0, row: 0 }, hideLabel: true },
-      id: '7',
-      concept: {
-        name: 'Pulse Abnormal',
-        uuid: 'c36c7c98-3f10-11e4-adec-0800271c1b75',
-        datatype: 'Boolean',
-        conceptClass: 'Abnormal',
-      },
-    },
-  ],
-};
 
 // Vitals group — demonstrates a richer multi-field obs group
 const vitalsMetadata = {

--- a/stories/Section.stories.js
+++ b/stories/Section.stories.js
@@ -1,21 +1,11 @@
 /* global componentStore */
 import React from 'react';
-import { NumericBox } from 'src/components/NumericBox.jsx';
-import { BooleanControl } from 'src/components/BooleanControl.jsx';
-import { Button } from 'src/components/Button.jsx';
 import StoryWrapper from './StoryWrapper';
-import { CodedControl } from 'src/components/CodedControl.jsx';
-import { AutoComplete } from 'src/components/AutoComplete.jsx';
-import { TextBox } from 'src/components/TextBox.jsx';
 import { Container } from 'src/components/Container.jsx';
 import { Section } from 'src/components/Section.jsx';
+import { registerCommonComponents } from './mockData';
 
-componentStore.registerComponent('numeric', NumericBox);
-componentStore.registerComponent('boolean', BooleanControl);
-componentStore.registerComponent('button', Button);
-componentStore.registerComponent('Coded', CodedControl);
-componentStore.registerComponent('autoComplete', AutoComplete);
-componentStore.registerComponent('text', TextBox);
+registerCommonComponents();
 componentStore.registerComponent('section', Section);
 
 // Section with two grouped controls (Notes + Abnormal toggle)

--- a/stories/Table.stories.js
+++ b/stories/Table.stories.js
@@ -1,21 +1,11 @@
 /* global componentStore */
 import React from 'react';
-import { NumericBox } from 'src/components/NumericBox.jsx';
-import { BooleanControl } from 'src/components/BooleanControl.jsx';
-import { Button } from 'src/components/Button.jsx';
-import { CodedControl } from 'src/components/CodedControl.jsx';
-import { AutoComplete } from 'src/components/AutoComplete.jsx';
-import { TextBox } from 'src/components/TextBox.jsx';
 import { Table } from 'src/components/Table.jsx';
 import { Container } from 'src/components/Container.jsx';
 import StoryWrapper from './StoryWrapper';
+import { systolicConcept, diastolicConcept, registerCommonComponents } from './mockData';
 
-componentStore.registerComponent('numeric', NumericBox);
-componentStore.registerComponent('boolean', BooleanControl);
-componentStore.registerComponent('button', Button);
-componentStore.registerComponent('Coded', CodedControl);
-componentStore.registerComponent('autoComplete', AutoComplete);
-componentStore.registerComponent('text', TextBox);
+registerCommonComponents();
 componentStore.registerComponent('table', Table);
 
 // Basic table: Lab results with three column headers and matching row controls
@@ -102,22 +92,14 @@ const tableWithDataForm = {
           label: { type: 'label', value: 'Systolic BP' },
           properties: { mandatory: true, location: { column: 0, row: 0 } },
           id: '6',
-          concept: {
-            name: 'Systolic',
-            uuid: 'c36e9c8b-3f10-11e4-adec-0800271c1b75',
-            datatype: 'Numeric',
-          },
+          concept: systolicConcept,
         },
         {
           type: 'obsControl',
           label: { type: 'label', value: 'Diastolic BP' },
           properties: { mandatory: true, location: { column: 0, row: 1 } },
           id: '7',
-          concept: {
-            name: 'Diastolic',
-            uuid: 'c379aa1d-3f10-11e4-adec-0800271c1b75',
-            datatype: 'Numeric',
-          },
+          concept: diastolicConcept,
         },
         {
           type: 'obsControl',
@@ -142,7 +124,7 @@ const tableWithDataObservations = [
     value: 120,
     formNamespace: 'bahmni',
     formFieldPath: 'Vitals Table.1/6-0',
-    concept: { name: 'Systolic', uuid: 'c36e9c8b-3f10-11e4-adec-0800271c1b75', datatype: 'Numeric' },
+    concept: systolicConcept,
   },
   {
     observationDateTime: '2026-04-28T09:00:00.000+0000',
@@ -150,7 +132,7 @@ const tableWithDataObservations = [
     value: 80,
     formNamespace: 'bahmni',
     formFieldPath: 'Vitals Table.1/7-0',
-    concept: { name: 'Diastolic', uuid: 'c379aa1d-3f10-11e4-adec-0800271c1b75', datatype: 'Numeric' },
+    concept: diastolicConcept,
   },
 ];
 

--- a/stories/mockData.js
+++ b/stories/mockData.js
@@ -1,0 +1,77 @@
+/* global componentStore */
+import { NumericBox } from 'src/components/NumericBox.jsx';
+import { BooleanControl } from 'src/components/BooleanControl.jsx';
+import { Button } from 'src/components/Button.jsx';
+import { CodedControl } from 'src/components/CodedControl.jsx';
+import { AutoComplete } from 'src/components/AutoComplete.jsx';
+import { TextBox } from 'src/components/TextBox.jsx';
+
+export const systolicConcept = {
+  name: 'Systolic',
+  uuid: 'c36e9c8b-3f10-11e4-adec-0800271c1b75',
+  datatype: 'Numeric',
+};
+
+export const diastolicConcept = {
+  name: 'Diastolic',
+  uuid: 'c379aa1d-3f10-11e4-adec-0800271c1b75',
+  datatype: 'Numeric',
+};
+
+export const pulseConcept = {
+  name: 'Pulse',
+  uuid: 'c36bc411-3f10-11e4-adec-0800271c1b75',
+  datatype: 'Numeric',
+  conceptClass: 'Misc',
+  lowNormal: 60,
+  hiNormal: 120,
+};
+
+export const pulseAbnormalConcept = {
+  name: 'Pulse Abnormal',
+  uuid: 'c36c7c98-3f10-11e4-adec-0800271c1b75',
+  datatype: 'Boolean',
+  conceptClass: 'Abnormal',
+};
+
+export const pulseDataConcept = {
+  name: 'Pulse Data',
+  uuid: 'c36af094-3f10-11e4-adec-0800271c1b75',
+  datatype: 'N/A',
+};
+
+// Pulse Data ObsGroup tree — used in ObsGroupControl and AbnormalObsControl stories
+export const pulseDataMetadata = {
+  type: 'ObsGroupControl',
+  concept: pulseDataConcept,
+  label: { type: 'label', value: 'Pulse Data' },
+  properties: { mandatory: false, location: { column: 0, row: 0 } },
+  id: '5',
+  controls: [
+    {
+      type: 'obsControl',
+      label: { type: 'label', value: 'Pulse' },
+      properties: { mandatory: false, location: { column: 0, row: 0 } },
+      id: '6',
+      concept: pulseConcept,
+    },
+    {
+      type: 'obsControl',
+      displayType: 'Button',
+      options: [{ name: 'Abnormal', value: true }],
+      label: { type: 'label', value: 'Abnormal' },
+      properties: { mandatory: false, location: { column: 0, row: 0 }, hideLabel: true },
+      id: '7',
+      concept: pulseAbnormalConcept,
+    },
+  ],
+};
+
+export function registerCommonComponents() {
+  componentStore.registerComponent('numeric', NumericBox);
+  componentStore.registerComponent('boolean', BooleanControl);
+  componentStore.registerComponent('button', Button);
+  componentStore.registerComponent('Coded', CodedControl);
+  componentStore.registerComponent('autoComplete', AutoComplete);
+  componentStore.registerComponent('text', TextBox);
+}


### PR DESCRIPTION
**JIRA**: BAH-4686

## What Changed

- `stories/mockData.js` (new): shared Storybook mock data module with concept objects, Pulse Data metadata tree, and `registerCommonComponents()` helper
- `stories/AbnormalObsControl.stories.js`: import `pulseDataMetadata` and `registerCommonComponents` from `./mockData`
- `stories/ObsGroupControl.stories.js`: import `pulseDataMetadata` (as `pulseMetadata`) and `registerCommonComponents` from `./mockData`
- `stories/Forms.stories.js`: import and use `systolicConcept` for Systolic (Numeric) control
- `stories/ObsControl.stories.js`: import and use `systolicConcept` for Systolic (Numeric) control
- `stories/Table.stories.js`: use `registerCommonComponents()` + use `systolicConcept`/`diastolicConcept` in vitals data
- `stories/Section.stories.js`: use `registerCommonComponents()`, remove now-unused component imports

## Why

Extracts byte-for-byte duplicate mock data (Pulse Data metadata tree, 6-component registration block, Systolic/Diastolic concept objects) from Storybook story files into a single shared module. Any future change to a shared concept UUID or the common component registration list now happens in one place.

## How Tested

- [x] All existing tests passing (1414/1414)
- [x] Lint passing (0 errors)
- [x] Story render output verified unchanged (no logic or component changes)

## Acceptance Criteria Met

- [x] Create `stories/mockData.js` to hold shared mock data
- [x] Extract duplicated Pulse Data ObsGroup metadata tree
- [x] Extract duplicated `componentStore.registerComponent` block
- [x] Extract recurring Systolic/Diastolic concept objects
- [x] Update affected story files to import from `stories/mockData.js`
- [x] Stories continue to render identically
- [x] All existing tests/linting continue to pass