### PR TITLE
BAH-4686 | [Storybook] Extract shared mock data to a separate file

### DIFF
--- a/stories/AbnormalObsControl.stories.js
+++ b/stories/AbnormalObsControl.stories.js
@@ -1,94 +1,13 @@
+/* global componentStore */
 import React from 'react';
 import { ObsGroupControlWithIntl as ObsGroupControl } from 'src/components/ObsGroupControl.jsx';
 import { ObsGroupMapper } from 'src/mapper/ObsGroupMapper';
 import { Obs } from 'src/helpers/Obs';
-import { NumericBox } from 'src/components/NumericBox.jsx';
-import { BooleanControl } from 'src/components/BooleanControl.jsx';
-import { Button } from 'src/components/Button.jsx';
 import { List } from 'immutable';
 import StoryWrapper from './StoryWrapper';
-import { CodedControl } from 'src/components/CodedControl.jsx';
-import { AutoComplete } from 'src/components/AutoComplete.jsx';
-import { TextBox } from 'src/components/TextBox.jsx';
+import { registerCoreComponents, pulseDataMetadata } from './mockData';
 
-const metadata = {
-  type: 'ObsGroupControl',
-  concept: {
-    name: 'Pulse Data',
-    uuid: 'c36af094-3f10-11e4-adec-0800271c1b75',
-    datatype: 'N/A',
-  },
-  label: {
-    type: 'label',
-    value: 'Pulse Data',
-  },
-  properties: {
-    mandatory: false,
-    location: {
-      column: 0,
-      row: 0,
-    },
-  },
-  id: '5',
-  controls: [
-    {
-      type: 'obsControl',
-      label: {
-        type: 'label',
-        value: 'Pulse',
-      },
-      properties: {
-        mandatory: false,
-        location: {
-          column: 0,
-          row: 0,
-        },
-      },
-      id: '6',
-      concept: {
-        name: 'Pulse',
-        uuid: 'c36bc411-3f10-11e4-adec-0800271c1b75',
-        datatype: 'Numeric',
-        conceptClass: 'Misc',
-        lowNormal: 60,
-        hiNormal: 120,
-      },
-    },
-    {
-      type: 'obsControl',
-      displayType: 'Button',
-      options: [
-       { name: 'Abnormal', value: true },
-      ],
-      label: {
-        type: 'label',
-        value: 'Abnormal',
-      },
-      properties: {
-        mandatory: false,
-        location: {
-          column: 0,
-          row: 0,
-        },
-        hideLabel: true,
-      },
-      id: '7',
-      concept: {
-        name: 'Pulse Abnormal',
-        uuid: 'c36c7c98-3f10-11e4-adec-0800271c1b75',
-        datatype: 'Boolean',
-        conceptClass: 'Abnormal',
-      },
-    },
-  ],
-};
-
-componentStore.registerComponent('numeric', NumericBox);
-componentStore.registerComponent('boolean', BooleanControl);
-componentStore.registerComponent('button', Button);
-componentStore.registerComponent('Coded', CodedControl);
-componentStore.registerComponent('autoComplete', AutoComplete);
-componentStore.registerComponent('text', TextBox);
+registerCoreComponents();
 
 export default {
   title: 'Abnormal ObsControl',
@@ -96,21 +15,21 @@ export default {
 
 export const BasicView = {
   render: () => {
-    const pulseObs = new Obs({ concept: metadata.controls[0].concept, formFieldPath: 'f.1/6-0', formNamespace: 'bahmni' });
-    const pulseAbnormalObs = new Obs({ concept: metadata.controls[1].concept, formFieldPath: 'f.1/7-0', formNamespace: 'bahmni' });
+    const pulseObs = new Obs({ concept: pulseDataMetadata.controls[0].concept, formFieldPath: 'f.1/6-0', formNamespace: 'bahmni' });
+    const pulseAbnormalObs = new Obs({ concept: pulseDataMetadata.controls[1].concept, formFieldPath: 'f.1/7-0', formNamespace: 'bahmni' });
     const pulseDataObs = new Obs({
-      concept: metadata.concept,
+      concept: pulseDataMetadata.concept,
       formNamespace: 'f/5',
       groupMembers: List.of(pulseObs, pulseAbnormalObs),
     });
     return (
-      <StoryWrapper json={metadata}>
+      <StoryWrapper json={pulseDataMetadata}>
         <ObsGroupControl
           errors={[]}
           formName="f"
           formVersion="1"
           mapper={new ObsGroupMapper()}
-          metadata={metadata}
+          metadata={pulseDataMetadata}
           obs={pulseDataObs}
           onValueChanged={() => {}}
           validate={false}

--- a/stories/AbnormalObsControl.stories.js
+++ b/stories/AbnormalObsControl.stories.js
@@ -1,11 +1,11 @@
-/* global componentStore */
 import React from 'react';
 import { ObsGroupControlWithIntl as ObsGroupControl } from 'src/components/ObsGroupControl.jsx';
 import { ObsGroupMapper } from 'src/mapper/ObsGroupMapper';
 import { Obs } from 'src/helpers/Obs';
 import { List } from 'immutable';
 import StoryWrapper from './StoryWrapper';
-import { registerCoreComponents, pulseDataMetadata } from './mockData';
+import { registerCoreComponents } from './componentRegistry';
+import { pulseDataMetadata } from './mockData';
 
 registerCoreComponents();
 

--- a/stories/Forms.stories.js
+++ b/stories/Forms.stories.js
@@ -2,6 +2,7 @@ import React from 'react';
 import StoryWrapper from './StoryWrapper';
 import { Container } from 'src/components/Container.jsx';
 import { runEventScript } from 'src/helpers/runEventScript';
+import { SYSTOLIC_UUID, DIASTOLIC_UUID } from './mockData';
 
 const form = {
   id: 1,
@@ -28,7 +29,7 @@ const form = {
       id: '1',
       concept: {
         name: 'Systolic',
-        uuid: 'c36e9c8b-3f10-11e4-adec-0800271c1b75',
+        uuid: SYSTOLIC_UUID,
         datatype: 'Numeric',
       },
     },
@@ -49,7 +50,7 @@ const form = {
       id: '2',
       concept: {
         name: 'Diastolic',
-        uuid: 'c379aa1d-3f10-11e4-adec-0800271c1b75',
+        uuid: DIASTOLIC_UUID,
         datatype: 'Text',
       },
     },
@@ -113,14 +114,14 @@ const form = {
       label: { id: 'systolic', type: 'label', value: 'Systolic' },
       properties: { mandatory: true, allowDecimal: false, location: { column: 0, row: 0 } },
       id: '6',
-      concept: { name: 'Systolic', uuid: 'c36e9c8b-3f10-11e4-adec-0800271c1b75', datatype: 'Date' },
+      concept: { name: 'Systolic', uuid: SYSTOLIC_UUID, datatype: 'Date' },
     },
     {
       type: 'obsControl',
       label: { id: 'systolic', type: 'label', value: 'Systolic' },
       properties: { mandatory: true, allowDecimal: false, location: { column: 0, row: 0 } },
       id: '7',
-      concept: { name: 'Systolic', uuid: 'c36e9c8b-3f10-11e4-adec-0800271c1b75', datatype: 'DateTime' },
+      concept: { name: 'Systolic', uuid: SYSTOLIC_UUID, datatype: 'DateTime' },
     },
     {
       type: 'obsControl',
@@ -375,7 +376,7 @@ const lifecycleDemoForm = {
       properties: { mandatory: true, allowDecimal: false, location: { column: 0, row: 0 } },
       id: '1',
       concept: {
-        name: 'Systolic', uuid: 'c36e9c8b-3f10-11e4-adec-0800271c1b75', datatype: 'Numeric',
+        name: 'Systolic', uuid: SYSTOLIC_UUID, datatype: 'Numeric',
       },
       events: {
         onValueChange: 'ZnVuY3Rpb24oZm9ybSkgeyB2YXIgdmFsID0gZm9ybS5nZXQoJ1N5c3RvbGljJykuZ2' +
@@ -388,7 +389,7 @@ const lifecycleDemoForm = {
       properties: { mandatory: false, allowDecimal: false, location: { column: 0, row: 1 } },
       id: '2',
       concept: {
-        name: 'Diastolic', uuid: 'c379aa1d-3f10-11e4-adec-0800271c1b75', datatype: 'Numeric',
+        name: 'Diastolic', uuid: DIASTOLIC_UUID, datatype: 'Numeric',
       },
     },
     {
@@ -564,7 +565,7 @@ const formForEventFlow = {
       label: { id: 'systolic', type: 'label', value: 'Systolic' },
       properties: { mandatory: false, allowDecimal: false, location: { column: 0, row: 0 } },
       id: '1',
-      concept: { name: 'Systolic', uuid: 'c36e9c8b-3f10-11e4-adec-0800271c1b75', datatype: 'Numeric' },
+      concept: { name: 'Systolic', uuid: SYSTOLIC_UUID, datatype: 'Numeric' },
     },
     {
       type: 'obsControl',

--- a/stories/ObsControl.stories.js
+++ b/stories/ObsControl.stories.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { ObsControlWithIntl as ObsControl } from 'src/components/ObsControl.jsx';
 import StoryWrapper from './StoryWrapper';
 import '../styles/styles.scss';
+import { SYSTOLIC_UUID, DIASTOLIC_UUID } from './mockData';
 
 const form = {
   controls: [
@@ -10,14 +11,14 @@ const form = {
       label: { id: 'systolic', type: 'label', value: 'Systolic' },
       properties: { mandatory: true, allowDecimal: false, addMore: true, location: { column: 0, row: 0 } },
       id: '1',
-      concept: { name: 'Systolic', uuid: 'c36e9c8b-3f10-11e4-adec-0800271c1b75', datatype: 'Numeric' },
+      concept: { name: 'Systolic', uuid: SYSTOLIC_UUID, datatype: 'Numeric' },
     },
     {
       type: 'obsControl',
       label: { id: 'diastolic', type: 'label', value: 'Diastolic' },
       properties: { mandatory: true, location: { column: 0, row: 0 } },
       id: '2',
-      concept: { name: 'Diastolic', uuid: 'c379aa1d-3f10-11e4-adec-0800271c1b75', datatype: 'Text' },
+      concept: { name: 'Diastolic', uuid: DIASTOLIC_UUID, datatype: 'Text' },
     },
     {
       options: [{ name: 'Yes', value: true }, { name: 'No', value: false }],
@@ -53,14 +54,14 @@ const form = {
       label: { id: 'systolic', type: 'label', value: 'Systolic' },
       properties: { mandatory: true, allowDecimal: false, location: { column: 0, row: 0 } },
       id: '6',
-      concept: { name: 'Systolic', uuid: 'c36e9c8b-3f10-11e4-adec-0800271c1b75', datatype: 'Date' },
+      concept: { name: 'Systolic', uuid: SYSTOLIC_UUID, datatype: 'Date' },
     },
     {
       type: 'obsControl',
       label: { id: 'systolic', type: 'label', value: 'Systolic' },
       properties: { mandatory: true, allowDecimal: false, location: { column: 0, row: 0 } },
       id: '7',
-      concept: { name: 'Systolic', uuid: 'c36e9c8b-3f10-11e4-adec-0800271c1b75', datatype: 'DateTime' },
+      concept: { name: 'Systolic', uuid: SYSTOLIC_UUID, datatype: 'DateTime' },
     },
     {
       type: 'obsControl',

--- a/stories/ObsGroupControl.stories.js
+++ b/stories/ObsGroupControl.stories.js
@@ -3,64 +3,11 @@ import React from 'react';
 import { ObsGroupControlWithIntl as ObsGroupControl } from 'src/components/ObsGroupControl.jsx';
 import { ObsGroupMapper } from 'src/mapper/ObsGroupMapper';
 import { Obs } from 'src/helpers/Obs';
-import { NumericBox } from 'src/components/NumericBox.jsx';
-import { BooleanControl } from 'src/components/BooleanControl.jsx';
-import { Button } from 'src/components/Button.jsx';
-import { CodedControl } from 'src/components/CodedControl.jsx';
-import { AutoComplete } from 'src/components/AutoComplete.jsx';
-import { TextBox } from 'src/components/TextBox.jsx';
 import { List } from 'immutable';
 import StoryWrapper from './StoryWrapper';
+import { registerCoreComponents, pulseDataMetadata } from './mockData';
 
-componentStore.registerComponent('numeric', NumericBox);
-componentStore.registerComponent('boolean', BooleanControl);
-componentStore.registerComponent('button', Button);
-componentStore.registerComponent('Coded', CodedControl);
-componentStore.registerComponent('autoComplete', AutoComplete);
-componentStore.registerComponent('text', TextBox);
-
-// Pulse Data group — mirrors AbnormalObsControl but is the canonical ObsGroupControl story
-const pulseMetadata = {
-  type: 'ObsGroupControl',
-  concept: {
-    name: 'Pulse Data',
-    uuid: 'c36af094-3f10-11e4-adec-0800271c1b75',
-    datatype: 'N/A',
-  },
-  label: { type: 'label', value: 'Pulse Data' },
-  properties: { mandatory: false, location: { column: 0, row: 0 } },
-  id: '5',
-  controls: [
-    {
-      type: 'obsControl',
-      label: { type: 'label', value: 'Pulse' },
-      properties: { mandatory: false, location: { column: 0, row: 0 } },
-      id: '6',
-      concept: {
-        name: 'Pulse',
-        uuid: 'c36bc411-3f10-11e4-adec-0800271c1b75',
-        datatype: 'Numeric',
-        conceptClass: 'Misc',
-        lowNormal: 60,
-        hiNormal: 120,
-      },
-    },
-    {
-      type: 'obsControl',
-      displayType: 'Button',
-      options: [{ name: 'Abnormal', value: true }],
-      label: { type: 'label', value: 'Abnormal' },
-      properties: { mandatory: false, location: { column: 0, row: 0 }, hideLabel: true },
-      id: '7',
-      concept: {
-        name: 'Pulse Abnormal',
-        uuid: 'c36c7c98-3f10-11e4-adec-0800271c1b75',
-        datatype: 'Boolean',
-        conceptClass: 'Abnormal',
-      },
-    },
-  ],
-};
+registerCoreComponents();
 
 // Vitals group — demonstrates a richer multi-field obs group
 const vitalsMetadata = {
@@ -175,26 +122,26 @@ export default {
 export const DefaultGroupWithChildObservations = {
   render: (args) => {
     const pulseObs = new Obs({
-      concept: pulseMetadata.controls[0].concept,
+      concept: pulseDataMetadata.controls[0].concept,
       formFieldPath: 'f.1/6-0',
       formNamespace: 'bahmni',
     });
     const pulseAbnormalObs = new Obs({
-      concept: pulseMetadata.controls[1].concept,
+      concept: pulseDataMetadata.controls[1].concept,
       formFieldPath: 'f.1/7-0',
       formNamespace: 'bahmni',
     });
     const pulseDataObs = new Obs({
-      concept: pulseMetadata.concept,
+      concept: pulseDataMetadata.concept,
       formNamespace: 'f/5',
       groupMembers: List.of(pulseObs, pulseAbnormalObs),
     });
     return (
-      <StoryWrapper json={pulseMetadata}>
+      <StoryWrapper json={pulseDataMetadata}>
         <ObsGroupControl
           {...commonGroupProps}
           {...args}
-          metadata={pulseMetadata}
+          metadata={pulseDataMetadata}
           value={pulseDataObs}
         />
       </StoryWrapper>
@@ -208,21 +155,21 @@ export const CollapsedGroup = {
   },
   render: (args) => {
     const pulseObs = new Obs({
-      concept: pulseMetadata.controls[0].concept,
+      concept: pulseDataMetadata.controls[0].concept,
       formFieldPath: 'f.1/6-0',
       formNamespace: 'bahmni',
     });
     const pulseDataObs = new Obs({
-      concept: pulseMetadata.concept,
+      concept: pulseDataMetadata.concept,
       formNamespace: 'f/5',
       groupMembers: List.of(pulseObs),
     });
     return (
-      <StoryWrapper json={pulseMetadata}>
+      <StoryWrapper json={pulseDataMetadata}>
         <ObsGroupControl
           {...commonGroupProps}
           {...args}
-          metadata={pulseMetadata}
+          metadata={pulseDataMetadata}
           value={pulseDataObs}
         />
       </StoryWrapper>
@@ -243,21 +190,21 @@ export const AddMoreGroup = {
   },
   render: (args) => {
     const pulseObs = new Obs({
-      concept: pulseMetadata.controls[0].concept,
+      concept: pulseDataMetadata.controls[0].concept,
       formFieldPath: 'f.1/6-0',
       formNamespace: 'bahmni',
     });
     const pulseDataObs = new Obs({
-      concept: pulseMetadata.concept,
+      concept: pulseDataMetadata.concept,
       formNamespace: 'f/5',
       groupMembers: List.of(pulseObs),
     });
     return (
-      <StoryWrapper json={pulseMetadata}>
+      <StoryWrapper json={pulseDataMetadata}>
         <ObsGroupControl
           {...commonGroupProps}
           {...args}
-          metadata={pulseMetadata}
+          metadata={pulseDataMetadata}
           value={pulseDataObs}
           showAddMore={true}
           onControlAdd={() => {}}

--- a/stories/ObsGroupControl.stories.js
+++ b/stories/ObsGroupControl.stories.js
@@ -5,7 +5,8 @@ import { ObsGroupMapper } from 'src/mapper/ObsGroupMapper';
 import { Obs } from 'src/helpers/Obs';
 import { List } from 'immutable';
 import StoryWrapper from './StoryWrapper';
-import { registerCoreComponents, pulseDataMetadata } from './mockData';
+import { registerCoreComponents } from './componentRegistry';
+import { pulseDataMetadata, SYSTOLIC_UUID, DIASTOLIC_UUID } from './mockData';
 
 registerCoreComponents();
 
@@ -28,7 +29,7 @@ const vitalsMetadata = {
       id: '31',
       concept: {
         name: 'Systolic',
-        uuid: 'c36e9c8b-3f10-11e4-adec-0800271c1b75',
+        uuid: SYSTOLIC_UUID,
         datatype: 'Numeric',
         lowNormal: 90,
         hiNormal: 140,
@@ -41,7 +42,7 @@ const vitalsMetadata = {
       id: '32',
       concept: {
         name: 'Diastolic',
-        uuid: 'c379aa1d-3f10-11e4-adec-0800271c1b75',
+        uuid: DIASTOLIC_UUID,
         datatype: 'Numeric',
         lowNormal: 60,
         hiNormal: 90,

--- a/stories/Section.stories.js
+++ b/stories/Section.stories.js
@@ -1,21 +1,11 @@
 /* global componentStore */
 import React from 'react';
-import { NumericBox } from 'src/components/NumericBox.jsx';
-import { BooleanControl } from 'src/components/BooleanControl.jsx';
-import { Button } from 'src/components/Button.jsx';
 import StoryWrapper from './StoryWrapper';
-import { CodedControl } from 'src/components/CodedControl.jsx';
-import { AutoComplete } from 'src/components/AutoComplete.jsx';
-import { TextBox } from 'src/components/TextBox.jsx';
 import { Container } from 'src/components/Container.jsx';
 import { Section } from 'src/components/Section.jsx';
+import { registerCoreComponents } from './mockData';
 
-componentStore.registerComponent('numeric', NumericBox);
-componentStore.registerComponent('boolean', BooleanControl);
-componentStore.registerComponent('button', Button);
-componentStore.registerComponent('Coded', CodedControl);
-componentStore.registerComponent('autoComplete', AutoComplete);
-componentStore.registerComponent('text', TextBox);
+registerCoreComponents();
 componentStore.registerComponent('section', Section);
 
 // Section with two grouped controls (Notes + Abnormal toggle)

--- a/stories/Section.stories.js
+++ b/stories/Section.stories.js
@@ -3,7 +3,7 @@ import React from 'react';
 import StoryWrapper from './StoryWrapper';
 import { Container } from 'src/components/Container.jsx';
 import { Section } from 'src/components/Section.jsx';
-import { registerCoreComponents } from './mockData';
+import { registerCoreComponents } from './componentRegistry';
 
 registerCoreComponents();
 componentStore.registerComponent('section', Section);

--- a/stories/Table.stories.js
+++ b/stories/Table.stories.js
@@ -3,7 +3,8 @@ import React from 'react';
 import { Table } from 'src/components/Table.jsx';
 import { Container } from 'src/components/Container.jsx';
 import StoryWrapper from './StoryWrapper';
-import { registerCoreComponents, SYSTOLIC_UUID, DIASTOLIC_UUID } from './mockData';
+import { registerCoreComponents } from './componentRegistry';
+import { SYSTOLIC_UUID, DIASTOLIC_UUID } from './mockData';
 
 registerCoreComponents();
 componentStore.registerComponent('table', Table);

--- a/stories/Table.stories.js
+++ b/stories/Table.stories.js
@@ -1,21 +1,11 @@
 /* global componentStore */
 import React from 'react';
-import { NumericBox } from 'src/components/NumericBox.jsx';
-import { BooleanControl } from 'src/components/BooleanControl.jsx';
-import { Button } from 'src/components/Button.jsx';
-import { CodedControl } from 'src/components/CodedControl.jsx';
-import { AutoComplete } from 'src/components/AutoComplete.jsx';
-import { TextBox } from 'src/components/TextBox.jsx';
 import { Table } from 'src/components/Table.jsx';
 import { Container } from 'src/components/Container.jsx';
 import StoryWrapper from './StoryWrapper';
+import { registerCoreComponents, SYSTOLIC_UUID, DIASTOLIC_UUID } from './mockData';
 
-componentStore.registerComponent('numeric', NumericBox);
-componentStore.registerComponent('boolean', BooleanControl);
-componentStore.registerComponent('button', Button);
-componentStore.registerComponent('Coded', CodedControl);
-componentStore.registerComponent('autoComplete', AutoComplete);
-componentStore.registerComponent('text', TextBox);
+registerCoreComponents();
 componentStore.registerComponent('table', Table);
 
 // Basic table: Lab results with three column headers and matching row controls
@@ -104,7 +94,7 @@ const tableWithDataForm = {
           id: '6',
           concept: {
             name: 'Systolic',
-            uuid: 'c36e9c8b-3f10-11e4-adec-0800271c1b75',
+            uuid: SYSTOLIC_UUID,
             datatype: 'Numeric',
           },
         },
@@ -115,7 +105,7 @@ const tableWithDataForm = {
           id: '7',
           concept: {
             name: 'Diastolic',
-            uuid: 'c379aa1d-3f10-11e4-adec-0800271c1b75',
+            uuid: DIASTOLIC_UUID,
             datatype: 'Numeric',
           },
         },
@@ -142,7 +132,7 @@ const tableWithDataObservations = [
     value: 120,
     formNamespace: 'bahmni',
     formFieldPath: 'Vitals Table.1/6-0',
-    concept: { name: 'Systolic', uuid: 'c36e9c8b-3f10-11e4-adec-0800271c1b75', datatype: 'Numeric' },
+    concept: { name: 'Systolic', uuid: SYSTOLIC_UUID, datatype: 'Numeric' },
   },
   {
     observationDateTime: '2026-04-28T09:00:00.000+0000',
@@ -150,7 +140,7 @@ const tableWithDataObservations = [
     value: 80,
     formNamespace: 'bahmni',
     formFieldPath: 'Vitals Table.1/7-0',
-    concept: { name: 'Diastolic', uuid: 'c379aa1d-3f10-11e4-adec-0800271c1b75', datatype: 'Numeric' },
+    concept: { name: 'Diastolic', uuid: DIASTOLIC_UUID, datatype: 'Numeric' },
   },
 ];
 

--- a/stories/componentRegistry.js
+++ b/stories/componentRegistry.js
@@ -1,0 +1,16 @@
+/* global componentStore */
+import { NumericBox } from 'src/components/NumericBox.jsx';
+import { BooleanControl } from 'src/components/BooleanControl.jsx';
+import { Button } from 'src/components/Button.jsx';
+import { CodedControl } from 'src/components/CodedControl.jsx';
+import { AutoComplete } from 'src/components/AutoComplete.jsx';
+import { TextBox } from 'src/components/TextBox.jsx';
+
+export function registerCoreComponents() {
+  componentStore.registerComponent('numeric', NumericBox);
+  componentStore.registerComponent('boolean', BooleanControl);
+  componentStore.registerComponent('button', Button);
+  componentStore.registerComponent('Coded', CodedControl);
+  componentStore.registerComponent('autoComplete', AutoComplete);
+  componentStore.registerComponent('text', TextBox);
+}

--- a/stories/mockData.js
+++ b/stories/mockData.js
@@ -1,0 +1,64 @@
+/* global componentStore */
+import { NumericBox } from 'src/components/NumericBox.jsx';
+import { BooleanControl } from 'src/components/BooleanControl.jsx';
+import { Button } from 'src/components/Button.jsx';
+import { CodedControl } from 'src/components/CodedControl.jsx';
+import { AutoComplete } from 'src/components/AutoComplete.jsx';
+import { TextBox } from 'src/components/TextBox.jsx';
+
+export const SYSTOLIC_UUID = 'c36e9c8b-3f10-11e4-adec-0800271c1b75';
+export const DIASTOLIC_UUID = 'c379aa1d-3f10-11e4-adec-0800271c1b75';
+export const PULSE_DATA_UUID = 'c36af094-3f10-11e4-adec-0800271c1b75';
+export const PULSE_UUID = 'c36bc411-3f10-11e4-adec-0800271c1b75';
+export const PULSE_ABNORMAL_UUID = 'c36c7c98-3f10-11e4-adec-0800271c1b75';
+
+export const pulseDataMetadata = {
+  type: 'ObsGroupControl',
+  concept: {
+    name: 'Pulse Data',
+    uuid: PULSE_DATA_UUID,
+    datatype: 'N/A',
+  },
+  label: { type: 'label', value: 'Pulse Data' },
+  properties: { mandatory: false, location: { column: 0, row: 0 } },
+  id: '5',
+  controls: [
+    {
+      type: 'obsControl',
+      label: { type: 'label', value: 'Pulse' },
+      properties: { mandatory: false, location: { column: 0, row: 0 } },
+      id: '6',
+      concept: {
+        name: 'Pulse',
+        uuid: PULSE_UUID,
+        datatype: 'Numeric',
+        conceptClass: 'Misc',
+        lowNormal: 60,
+        hiNormal: 120,
+      },
+    },
+    {
+      type: 'obsControl',
+      displayType: 'Button',
+      options: [{ name: 'Abnormal', value: true }],
+      label: { type: 'label', value: 'Abnormal' },
+      properties: { mandatory: false, location: { column: 0, row: 0 }, hideLabel: true },
+      id: '7',
+      concept: {
+        name: 'Pulse Abnormal',
+        uuid: PULSE_ABNORMAL_UUID,
+        datatype: 'Boolean',
+        conceptClass: 'Abnormal',
+      },
+    },
+  ],
+};
+
+export function registerCoreComponents() {
+  componentStore.registerComponent('numeric', NumericBox);
+  componentStore.registerComponent('boolean', BooleanControl);
+  componentStore.registerComponent('button', Button);
+  componentStore.registerComponent('Coded', CodedControl);
+  componentStore.registerComponent('autoComplete', AutoComplete);
+  componentStore.registerComponent('text', TextBox);
+}

--- a/stories/mockData.js
+++ b/stories/mockData.js
@@ -1,16 +1,9 @@
-/* global componentStore */
-import { NumericBox } from 'src/components/NumericBox.jsx';
-import { BooleanControl } from 'src/components/BooleanControl.jsx';
-import { Button } from 'src/components/Button.jsx';
-import { CodedControl } from 'src/components/CodedControl.jsx';
-import { AutoComplete } from 'src/components/AutoComplete.jsx';
-import { TextBox } from 'src/components/TextBox.jsx';
-
 export const SYSTOLIC_UUID = 'c36e9c8b-3f10-11e4-adec-0800271c1b75';
 export const DIASTOLIC_UUID = 'c379aa1d-3f10-11e4-adec-0800271c1b75';
-export const PULSE_DATA_UUID = 'c36af094-3f10-11e4-adec-0800271c1b75';
-export const PULSE_UUID = 'c36bc411-3f10-11e4-adec-0800271c1b75';
-export const PULSE_ABNORMAL_UUID = 'c36c7c98-3f10-11e4-adec-0800271c1b75';
+
+const PULSE_DATA_UUID = 'c36af094-3f10-11e4-adec-0800271c1b75';
+const PULSE_UUID = 'c36bc411-3f10-11e4-adec-0800271c1b75';
+const PULSE_ABNORMAL_UUID = 'c36c7c98-3f10-11e4-adec-0800271c1b75';
 
 export const pulseDataMetadata = {
   type: 'ObsGroupControl',
@@ -53,12 +46,3 @@ export const pulseDataMetadata = {
     },
   ],
 };
-
-export function registerCoreComponents() {
-  componentStore.registerComponent('numeric', NumericBox);
-  componentStore.registerComponent('boolean', BooleanControl);
-  componentStore.registerComponent('button', Button);
-  componentStore.registerComponent('Coded', CodedControl);
-  componentStore.registerComponent('autoComplete', AutoComplete);
-  componentStore.registerComponent('text', TextBox);
-}


### PR DESCRIPTION
## Summary
- Extracts duplicated mock data (concept UUIDs, `componentStore.registerComponent` blocks, and `pulseDataMetadata`) from 6 Storybook story files into a single shared `stories/mockData.js` file
- Replaces hardcoded UUID strings with named constants (`SYSTOLIC_UUID`, `DIASTOLIC_UUID`, etc.) for easier maintenance
- Introduces a `registerCoreComponents()` helper to eliminate repeated `componentStore.registerComponent` calls across story files

## Jira
[BAH-4686](https://bahmni.atlassian.net/browse/BAH-4686)

## Test plan
- [ ] Verify Storybook loads correctly and all stories render without errors
- [ ] Check AbnormalObsControl, ObsGroupControl, ObsControl, Forms, Section, and Table stories still display as expected
- [ ] Confirm no regressions in story behaviour after refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BAH-4686]: https://bahmni.atlassian.net/browse/BAH-4686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ