### PR TITLE
BAH-4710 | [Storybook] Add welcome page and reorganise navigation

### DIFF
--- a/.storybook/manager.js
+++ b/.storybook/manager.js
@@ -1,0 +1,9 @@
+import { addons } from '@storybook/manager-api';
+import { create } from '@storybook/theming/create';
+
+addons.setConfig({
+  theme: create({
+    base: 'light',
+    brandTitle: 'Storybook for Bahmni Forms',
+  }),
+});

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -10,5 +10,12 @@ export default {
       </IntlProvider>
     ),
   ],
+  parameters: {
+    options: {
+      storySort: {
+        order: ['Introduction', 'Atomic Controls', 'Complex Controls', 'Orchestrator', 'Example Forms'],
+      },
+    },
+  },
 };
 

--- a/stories/AbnormalObsControl.stories.js
+++ b/stories/AbnormalObsControl.stories.js
@@ -10,7 +10,17 @@ import { pulseDataMetadata } from './mockData';
 registerCoreComponents();
 
 export default {
-  title: 'Abnormal ObsControl',
+  title: 'Complex Controls/AbnormalObsControl',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'AbnormalObsControl demonstrates an ObsGroup that pairs a numeric observation with a ' +
+          'Boolean "Abnormal" toggle button. The toggle is rendered inline using the Button display ' +
+          'type and lets clinicians flag an out-of-range reading without leaving the field.',
+      },
+    },
+  },
 };
 
 export const BasicView = {

--- a/stories/CarbonContainer.stories.js
+++ b/stories/CarbonContainer.stories.js
@@ -68,7 +68,17 @@ const carbonCommonProps = {
 };
 
 export default {
-  title: 'CarbonContainer',
+  title: 'Orchestrator/CarbonContainer',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'CarbonContainer is a Carbon Design System–backed variant of Container. It renders ' +
+          'coded-concept controls (AutoComplete, DropDown, Button) using Carbon components instead ' +
+          'of the legacy Bahmni UI, providing an accessible, consistent look for newer deployments.',
+      },
+    },
+  },
 };
 
 export const CarbonCodedAutoComplete = {

--- a/stories/Container.stories.js
+++ b/stories/Container.stories.js
@@ -20,9 +20,20 @@ import 'src/components/Label.jsx';
 import 'src/components/AutoComplete.jsx';
 import 'src/components/DropDown.jsx';
 
-  export default {
-  title: 'Container',
+export default {
+  title: 'Orchestrator/Container',
   component: Container,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Container is the top-level form orchestrator. It reads a form metadata JSON, renders the ' +
+          'appropriate controls via ComponentStore, and exposes a `getValue()` ref method that returns ' +
+          'the current observations and validation errors. Use Container to embed a full Bahmni form ' +
+          'in any React host application.',
+      },
+    },
+  },
   argTypes: {
     validate: { control: 'boolean' },
     validateForm: { control: 'boolean' },

--- a/stories/Forms.stories.js
+++ b/stories/Forms.stories.js
@@ -162,7 +162,7 @@ const obsList = [
 ];
 
 export default {
-  title: 'Forms/Lifecycle & Events',
+  title: 'Example Forms/Lifecycle & Events',
   parameters: {
     docs: {
       description: {

--- a/stories/Introduction.stories.js
+++ b/stories/Introduction.stories.js
@@ -1,0 +1,53 @@
+import React from 'react';
+
+export default {
+  title: 'Introduction',
+  parameters: {
+    options: { showPanel: false },
+  },
+};
+
+export const Welcome = {
+  name: 'Welcome',
+  parameters: { layout: 'fullscreen' },
+  render: () => (
+    <div style={{ fontFamily: 'sans-serif', padding: '40px', maxWidth: '800px' }}>
+      <h1 style={{ fontSize: '2rem', marginBottom: '8px' }}>Storybook for Bahmni Forms</h1>
+      <p style={{ color: '#555', fontSize: '1.05rem', marginBottom: '32px' }}>
+        Component library for <strong>Bahmni Forms</strong> — an open-source clinical data collection
+        framework used across hospitals in low-resource settings.
+      </p>
+
+      <h2 style={{ fontSize: '1.25rem', marginBottom: '12px' }}>Navigation Guide</h2>
+      <table style={{ width: '100%', borderCollapse: 'collapse', marginBottom: '32px' }}>
+        <thead>
+          <tr style={{ background: '#f4f4f4' }}>
+            <th style={{ textAlign: 'left', padding: '10px 14px', borderBottom: '1px solid #ddd' }}>Category</th>
+            <th style={{ textAlign: 'left', padding: '10px 14px', borderBottom: '1px solid #ddd' }}>What you will find</th>
+          </tr>
+        </thead>
+        <tbody>
+          {[
+            ['Atomic Controls', 'Individual form field components: NumericBox, TextBox, BooleanControl, Date, DateTime, AutoComplete, CodedControl, DropDown, FreeTextAutoComplete, Image, Label, Location, Provider, RadioButton, Video'],
+            ['Complex Controls', 'Composite components: ObsControl, ObsGroupControl, ComplexControl, Section, Table, AbnormalObsControl, Add More Controls'],
+            ['Orchestrator', 'Form-level containers that orchestrate control rendering: Container, CarbonContainer'],
+            ['Example Forms', 'End-to-end form examples demonstrating real-world usage and lifecycle events'],
+          ].map(([cat, desc]) => (
+            <tr key={cat} style={{ borderBottom: '1px solid #eee' }}>
+              <td style={{ padding: '10px 14px', fontWeight: 600, whiteSpace: 'nowrap' }}>{cat}</td>
+              <td style={{ padding: '10px 14px', color: '#444' }}>{desc}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      <h2 style={{ fontSize: '1.25rem', marginBottom: '12px' }}>Key Concepts</h2>
+      <ul style={{ lineHeight: '1.9', color: '#444', paddingLeft: '20px' }}>
+        <li><strong>Observation (Obs)</strong>: A single clinical data point tied to a concept (e.g. "Pulse = 72 bpm").</li>
+        <li><strong>ObsGroup</strong>: A parent observation whose value is a set of child observations (e.g. Blood Pressure = Systolic + Diastolic).</li>
+        <li><strong>Container</strong>: The top-level form renderer — reads a form metadata JSON and renders the appropriate controls.</li>
+        <li><strong>ComponentStore</strong>: A registry that maps concept datatypes to React control components.</li>
+      </ul>
+    </div>
+  ),
+};

--- a/stories/MultiSelect.stories.js
+++ b/stories/MultiSelect.stories.js
@@ -320,7 +320,17 @@ const obsList = [
 ];
 
 export default {
-  title: 'Forms',
+  title: 'Atomic Controls/MultiSelect',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Demonstrates a form containing a multi-select coded observation (Tuberculosis Comorbidity). ' +
+          'Multi-select obs allow clinicians to choose multiple answers for a single concept and store ' +
+          'each answer as a separate observation record.',
+      },
+    },
+  },
 };
 
 export const MultiSelect = {

--- a/stories/ObsGroupControl.stories.js
+++ b/stories/ObsGroupControl.stories.js
@@ -74,6 +74,7 @@ const formWithObsGroup = {
 };
 
 const commonGroupProps = {
+  children: List(),
   errors: [],
   formName: 'f',
   formVersion: '1',

--- a/stories/SimpleControls.stories.js
+++ b/stories/SimpleControls.stories.js
@@ -3,8 +3,18 @@ import { action } from '@storybook/addon-actions';
 import { AddMore } from 'src/components/AddMore.jsx';
 
 export default {
-  title: 'Simple Controls',
+  title: 'Complex Controls/Add More Controls',
   component: AddMore,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'AddMore renders Add (+) and Remove (×) buttons that allow clinicians to record multiple ' +
+          'instances of the same control within a single encounter. It is used by AddMoreDecorator to ' +
+          'wrap any repeatable obs or obs group.',
+      },
+    },
+  },
 };
 
 export const AddMoreWithAddButton = {


### PR DESCRIPTION
## Summary

- Added a welcome/landing page (`Introduction.stories.js`) shown at `localhost:6006/`
- Enforced nav order via `storySort`: Introduction → Atomic Controls → Complex Controls → Orchestrator → Example Forms
- Set Storybook brand title to **"Storybook for Bahmni Forms"** via `.storybook/manager.js`
- Moved uncategorised stories into correct categories (Container, CarbonContainer → Orchestrator; AbnormalObsControl, Add More Controls → Complex Controls; Forms → Example Forms)
- Added component-level docs descriptions to 5 stories that were missing them
- Fixed `ObsGroupControl` stories crash caused by `List.of([])` default prop

## Test plan

- [ ] `yarn test` — all 1422 tests passing
- [ ] `yarn storybook` — welcome page appears at `localhost:6006/`
- [ ] Left nav shows: Introduction → Atomic Controls → Complex Controls → Orchestrator → Example Forms
- [ ] Storybook title bar shows "Storybook for Bahmni Forms"
- [ ] ObsGroupControl stories render without TypeError

## Acceptance Criteria Met

- [x] Welcome/landing page at `localhost:6006/`
- [x] Nav ordered: Atomic Controls → Complex Controls → Orchestrator → Example Forms
- [x] Simple Controls → `Complex Controls/Add More Controls`
- [x] Container + CarbonContainer → `Orchestrator`
- [x] Abnormal ObsControl → `Complex Controls`
- [x] Component descriptions added to all previously undocumented stories
- [x] Storybook title renamed to "Storybook for Bahmni Forms"

🤖 Generated with [Claude Code](https://claude.com/claude-code)