### PR TITLE
BAH-4727|Fix Form metadata saving issue in form2-controls due to html escape from payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bahmni/form2-controls",
-  "version": "0.0.6",
+  "version": "0.0.3",
   "description": "Repository for form controls",
   "license": "MPL-2.0",
   "main": "./dist/bundle.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bahmni/form2-controls",
-  "version": "0.0.3",
+  "version": "0.0.6",
   "description": "Repository for form controls",
   "license": "MPL-2.0",
   "main": "./dist/bundle.js",
@@ -84,6 +84,7 @@
     "ajv": "^8.17.1",
     "base64-inline-loader": "^1.1.0",
     "classnames": "^2.2.5",
+    "html-entities": "^2.6.0",
     "immutable": "4.3.8",
     "lodash": "^4.17.21",
     "prop-types": "^15.6.2",

--- a/src/components/Container.jsx
+++ b/src/components/Container.jsx
@@ -19,6 +19,8 @@ export class Container extends addMoreDecorator(Component) {
     this.childControls = {};
     const { observations } = this.props;
     this.metadata = deepUnescapeStrings(this.props.metadata);
+    this._translationsInput = null;
+    this._decodedTranslations = {};
     const controlRecordTree = new ControlRecordTreeBuilder().build(this.metadata, observations);
     this.updatedControlRecordTree = controlRecordTree;
     this.state = { errors: [], data: controlRecordTree,
@@ -48,9 +50,11 @@ export class Container extends addMoreDecorator(Component) {
   }
 
   componentDidUpdate(prevProps) {
-    // Update collapse state when props change (moved from componentWillReceiveProps)
     if (prevProps.collapse !== this.props.collapse) {
       this.setState({ collapse: this.props.collapse });
+    }
+    if (prevProps.metadata !== this.props.metadata) {
+      this.metadata = deepUnescapeStrings(this.props.metadata);
     }
   }
 
@@ -181,11 +185,15 @@ export class Container extends addMoreDecorator(Component) {
   render() {
     const { controls, name: formName, version: formVersion } = this.metadata;
     const { validate, translations, patient, readonly } = this.props;
-    const rawTranslations = Object.fromEntries(
-      Object.entries({ ...translations.labels, ...translations.concepts })
-        .filter(([key, value]) => value !== key)
-    );
-    const formTranslations = deepUnescapeStrings(rawTranslations);
+    if (translations !== this._translationsInput) {
+      this._translationsInput = translations;
+      const rawTranslations = Object.fromEntries(
+        Object.entries({ ...translations.labels, ...translations.concepts })
+          .filter(([key, value]) => value !== key)
+      );
+      this._decodedTranslations = deepUnescapeStrings(rawTranslations);
+    }
+    const formTranslations = this._decodedTranslations;
     const patientUuid = patient ? patient.uuid : undefined;
     const childProps = {
       collapse: this.state.collapse,

--- a/src/components/Container.jsx
+++ b/src/components/Container.jsx
@@ -11,13 +11,15 @@ import ObservationMapper from '../helpers/ObservationMapper';
 import NotificationContainer from '../helpers/Notification';
 import Constants from '../constants';
 import { executeEventsFromCurrentRecord } from '../helpers/ExecuteEvents';
+import { deepUnescapeStrings } from '../helpers/encodingUtils';
 
 export class Container extends addMoreDecorator(Component) {
   constructor(props) {
     super(props);
     this.childControls = {};
-    const { observations, metadata } = this.props;
-    const controlRecordTree = new ControlRecordTreeBuilder().build(metadata, observations);
+    const { observations } = this.props;
+    this.metadata = deepUnescapeStrings(this.props.metadata);
+    const controlRecordTree = new ControlRecordTreeBuilder().build(this.metadata, observations);
     this.updatedControlRecordTree = controlRecordTree;
     this.state = { errors: [], data: controlRecordTree,
       collapse: props.collapse, notification: {} };
@@ -29,7 +31,7 @@ export class Container extends addMoreDecorator(Component) {
     this.showNotification = this.showNotification.bind(this);
     this.clearNotification = this.clearNotification.bind(this);
 
-    const initScript = this.props.metadata.events && this.props.metadata.events.onFormInit;
+    const initScript = this.metadata.events && this.metadata.events.onFormInit;
     let updatedTree;
     try {
       if (initScript) {
@@ -177,12 +179,13 @@ export class Container extends addMoreDecorator(Component) {
   }
 
   render() {
-    const { metadata: { controls,
-      name: formName, version: formVersion }, validate, translations, patient, readonly } = this.props;
-    const formTranslations = Object.fromEntries(
+    const { controls, name: formName, version: formVersion } = this.metadata;
+    const { validate, translations, patient, readonly } = this.props;
+    const rawTranslations = Object.fromEntries(
       Object.entries({ ...translations.labels, ...translations.concepts })
         .filter(([key, value]) => value !== key)
     );
+    const formTranslations = deepUnescapeStrings(rawTranslations);
     const patientUuid = patient ? patient.uuid : undefined;
     const childProps = {
       collapse: this.state.collapse,

--- a/src/components/Container.jsx
+++ b/src/components/Container.jsx
@@ -19,12 +19,11 @@ export class Container extends addMoreDecorator(Component) {
     this.childControls = {};
     const { observations } = this.props;
     this.metadata = deepUnescapeStrings(this.props.metadata);
-    this._translationsInput = null;
-    this._decodedTranslations = {};
     const controlRecordTree = new ControlRecordTreeBuilder().build(this.metadata, observations);
     this.updatedControlRecordTree = controlRecordTree;
+    const formTranslations = this.getDecodedTranslations(props.translations);
     this.state = { errors: [], data: controlRecordTree,
-      collapse: props.collapse, notification: {} };
+      collapse: props.collapse, notification: {}, formTranslations };
     this.storeChildRef = this.storeChildRef.bind(this);
     this.onValueChanged = this.onValueChanged.bind(this);
     this.onControlAdd = this.onControlAdd.bind(this);
@@ -49,12 +48,27 @@ export class Container extends addMoreDecorator(Component) {
     }
   }
 
+  getDecodedTranslations(translations) {
+    const rawTranslations = Object.fromEntries(
+      Object.entries({ ...translations.labels, ...translations.concepts })
+        .filter(([key, value]) => value !== key)
+    );
+    return deepUnescapeStrings(rawTranslations);
+  }
+
   componentDidUpdate(prevProps) {
     if (prevProps.collapse !== this.props.collapse) {
       this.setState({ collapse: this.props.collapse });
     }
     if (prevProps.metadata !== this.props.metadata) {
       this.metadata = deepUnescapeStrings(this.props.metadata);
+      const tree = new ControlRecordTreeBuilder().build(this.metadata, this.props.observations);
+      this.updatedControlRecordTree = tree;
+      this.setState({ data: tree });
+    }
+    if (prevProps.translations !== this.props.translations) {
+      const formTranslations = this.getDecodedTranslations(this.props.translations);
+      this.setState({ formTranslations });
     }
   }
 
@@ -184,16 +198,8 @@ export class Container extends addMoreDecorator(Component) {
 
   render() {
     const { controls, name: formName, version: formVersion } = this.metadata;
-    const { validate, translations, patient, readonly } = this.props;
-    if (translations !== this._translationsInput) {
-      this._translationsInput = translations;
-      const rawTranslations = Object.fromEntries(
-        Object.entries({ ...translations.labels, ...translations.concepts })
-          .filter(([key, value]) => value !== key)
-      );
-      this._decodedTranslations = deepUnescapeStrings(rawTranslations);
-    }
-    const formTranslations = this._decodedTranslations;
+    const { validate, patient, readonly } = this.props;
+    const formTranslations = this.state.formTranslations;
     const patientUuid = patient ? patient.uuid : undefined;
     const childProps = {
       collapse: this.state.collapse,

--- a/src/components/bahmni-design-system/Location.jsx
+++ b/src/components/bahmni-design-system/Location.jsx
@@ -90,7 +90,5 @@ Location.propTypes = {
 Location.defaultProps = {
   autofocus: false,
   enabled: true,
-  labelKey: 'name',
-  valueKey: 'id',
   searchable: false,
 };

--- a/src/components/bahmni-design-system/Location.jsx
+++ b/src/components/bahmni-design-system/Location.jsx
@@ -4,6 +4,7 @@ import { AutoComplete } from 'components/bahmni-design-system/AutoComplete';
 import { httpInterceptor } from 'src/helpers/httpInterceptor';
 import Constants from 'src/constants';
 import find from 'lodash/find';
+import { unescapeHtml } from 'src/helpers/encodingUtils';
 
 export class Location extends Component {
 
@@ -17,7 +18,7 @@ export class Location extends Component {
   componentDidMount() {
     this._isMounted = true;
     const { properties } = this.props;
-    const url = properties.URL || '/openmrs/ws/rest/v1/location?v=custom:(id,name,uuid)';
+    const url = unescapeHtml(properties.URL || '/openmrs/ws/rest/v1/location?v=custom:(id,name,uuid)');
     httpInterceptor
       .get(url)
       .then((data) => {
@@ -57,6 +58,7 @@ export class Location extends Component {
           conceptUuid={conceptUuid}
           enabled={enabled}
           formFieldPath={formFieldPath}
+          labelKey="name"
           minimumInput={minimumInput}
           multiSelect={false}
           onValueChange={this.onValueChange}

--- a/src/components/bahmni-design-system/Provider.jsx
+++ b/src/components/bahmni-design-system/Provider.jsx
@@ -5,6 +5,7 @@ import { httpInterceptor } from 'src/helpers/httpInterceptor';
 import Spinner from 'src/helpers/Spinner';
 import Constants from 'src/constants';
 import find from 'lodash/find';
+import { unescapeHtml } from 'src/helpers/encodingUtils';
 
 export class Provider extends Component {
 
@@ -18,7 +19,7 @@ export class Provider extends Component {
   componentDidMount() {
     this._isMounted = true;
     const { properties } = this.props;
-    const url = properties.URL || '/openmrs/ws/rest/v1/provider?v=custom:(id,name,uuid)';
+    const url = unescapeHtml(properties.URL || '/openmrs/ws/rest/v1/provider?v=custom:(id,name,uuid)');
     httpInterceptor
       .get(url)
       .then((data) => {
@@ -64,6 +65,7 @@ export class Provider extends Component {
         conceptUuid={conceptUuid}
         enabled={enabled}
         formFieldPath={formFieldPath}
+        labelKey="name"
         minimumInput={minimumInput}
         multiSelect={false}
         onValueChange={this.onValueChange}

--- a/src/components/bahmni-design-system/Provider.jsx
+++ b/src/components/bahmni-design-system/Provider.jsx
@@ -97,7 +97,5 @@ Provider.propTypes = {
 Provider.defaultProps = {
   autofocus: false,
   enabled: true,
-  labelKey: 'name',
-  valueKey: 'id',
   searchable: false,
 };

--- a/src/helpers/encodingUtils.js
+++ b/src/helpers/encodingUtils.js
@@ -1,58 +1,52 @@
-import { decode } from 'html-entities';
+import { decode } from "html-entities";
 
 export function unescapeHtml(str) {
-    if (typeof str !== 'string') return str;
-
-    let decoded = decode(str);
-    while (decoded !== str) {
-        str = decoded;
-        decoded = decode(str);
-    }
-    return decoded;
+  if (typeof str !== "string") return str;
+  return decode(str);
 }
 
 export function deepUnescapeStrings(obj) {
-    if (typeof obj === 'string') {
-        return unescapeHtml(obj);
+  if (typeof obj === "string") {
+    return unescapeHtml(obj);
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(deepUnescapeStrings);
+  }
+  if (typeof obj === "object" && obj !== null) {
+    const result = {};
+    for (const key of Object.keys(obj)) {
+      result[key] = deepUnescapeStrings(obj[key]);
     }
-    if (Array.isArray(obj)) {
-        return obj.map(deepUnescapeStrings);
-    }
-    if (typeof obj === 'object' && obj !== null) {
-        const result = {};
-        for (const key of Object.keys(obj)) {
-            result[key] = deepUnescapeStrings(obj[key]);
-        }
-        return result;
-    }
-    return obj;
+    return result;
+  }
+  return obj;
 }
 
 export function utf8ToBase64(str) {
-    if (str === undefined || str === null || str === '') {
-        return '';
-    }
-    const encoder = new TextEncoder();
-    const data = encoder.encode(str);
+  if (str === undefined || str === null || str === "") {
+    return "";
+  }
+  const encoder = new TextEncoder();
+  const data = encoder.encode(str);
 
-    const binaryString = String.fromCharCode.apply(null, data);
-    return btoa(binaryString);
+  const binaryString = String.fromCharCode.apply(null, data);
+  return btoa(binaryString);
 }
 
 export function base64ToUtf8(b64) {
-    if (b64 === undefined || b64 === null || b64 === '') {
-        return '';
+  if (b64 === undefined || b64 === null || b64 === "") {
+    return "";
+  }
+  try {
+    const binaryString = atob(b64);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+      bytes[i] = binaryString.charCodeAt(i);
     }
-    try {
-        const binaryString = atob(b64);
-        const bytes = new Uint8Array(binaryString.length);
-        for (let i = 0; i < binaryString.length; i++) {
-            bytes[i] = binaryString.charCodeAt(i);
-        }
-        const decoder = new TextDecoder();
-        return decoder.decode(bytes);
-    } catch (e) {
-        console.error('Error decoding base64 string:', e);
-        return '';
-    }
+    const decoder = new TextDecoder();
+    return decoder.decode(bytes);
+  } catch (e) {
+    console.error("Error decoding base64 string:", e);
+    return "";
+  }
 }

--- a/src/helpers/encodingUtils.js
+++ b/src/helpers/encodingUtils.js
@@ -1,3 +1,27 @@
+import { decode } from 'html-entities';
+
+export function unescapeHtml(str) {
+    if (typeof str !== 'string') return str;
+    return decode(str);
+}
+
+export function deepUnescapeStrings(obj) {
+    if (typeof obj === 'string') {
+        return unescapeHtml(obj);
+    }
+    if (Array.isArray(obj)) {
+        return obj.map(deepUnescapeStrings);
+    }
+    if (typeof obj === 'object' && obj !== null) {
+        const result = {};
+        for (const key of Object.keys(obj)) {
+            result[key] = deepUnescapeStrings(obj[key]);
+        }
+        return result;
+    }
+    return obj;
+}
+
 export function utf8ToBase64(str) {
     if (str === undefined || str === null || str === '') {
         return '';

--- a/src/helpers/encodingUtils.js
+++ b/src/helpers/encodingUtils.js
@@ -2,7 +2,13 @@ import { decode } from 'html-entities';
 
 export function unescapeHtml(str) {
     if (typeof str !== 'string') return str;
-    return decode(str);
+
+    let decoded = decode(str);
+    while (decoded !== str) {
+        str = decoded;
+        decoded = decode(str);
+    }
+    return decoded;
 }
 
 export function deepUnescapeStrings(obj) {

--- a/test/components/Container.test.js
+++ b/test/components/Container.test.js
@@ -599,6 +599,76 @@ describe('Container', () => {
       expect(screen.queryByText(/PULSE_LABEL/)).not.toBeInTheDocument();
       expect(screen.getByText(/Pulse/)).toBeInTheDocument();
     });
+
+    it('should render decoded HTML entities in concept labels and translations', () => {
+      const metadata = createNumericControlMetadata({
+        controls: [{
+          ...createNumericControlMetadata().controls[0],
+          label: { type: 'label', value: 'Blood Pressure &gt; 60', translationKey: 'BP_LABEL' },
+          concept: {
+            ...createNumericControlMetadata().controls[0].concept,
+            name: 'Vitals &amp; Parameters',
+          },
+        }],
+      });
+      const translations = {
+        labels: { BP_LABEL: 'Blood Pressure &gt; 60' },
+        concepts: {},
+      };
+
+      renderContainer({ metadata, translations });
+
+      // The label should display with decoded entity (> instead of &gt;)
+      expect(screen.getByText(/Blood Pressure > 60/)).toBeInTheDocument();
+      // The input should be associated with the decoded label
+      const input = screen.getByRole('spinbutton');
+      expect(input).toBeInTheDocument();
+    });
+
+    it('should decode HTML entities in concept descriptions', () => {
+      const metadata = createNumericControlMetadata({
+        controls: [{
+          ...createNumericControlMetadata().controls[0],
+          concept: {
+            ...createNumericControlMetadata().controls[0].concept,
+            description: 'Note: Use &lt;10mg &amp; monitor &gt; 60bpm',
+          },
+        }],
+      });
+
+      renderContainer({ metadata });
+      expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+    });
+
+    it('should decode HTML entities in control properties URL', () => {
+      const metadata = createNumericControlMetadata({
+        controls: [{
+          ...createNumericControlMetadata().controls[0],
+          properties: {
+            ...createNumericControlMetadata().controls[0].properties,
+            url: '/provider?attrName=type&amp;attrValue=Doctor',
+          },
+        }],
+      });
+
+      renderContainer({ metadata });
+      expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+    });
+
+    it('should decode HTML entities in onFormInit script', async () => {
+      const metadata = createNumericControlMetadata({
+        events: {
+          onFormInit: utf8ToBase64("function(form){form.get('Pulse').setEnabled(false);}"),
+        },
+      });
+
+      renderContainer({ metadata });
+
+      await waitFor(() => {
+        const input = screen.getByRole('spinbutton');
+        expect(input).toBeDisabled();
+      });
+    });
   });
 
   describe('Coverage Improvements', () => {

--- a/test/components/Container.test.js
+++ b/test/components/Container.test.js
@@ -625,50 +625,6 @@ describe('Container', () => {
       expect(input).toBeInTheDocument();
     });
 
-    it('should decode HTML entities in concept descriptions', () => {
-      const metadata = createNumericControlMetadata({
-        controls: [{
-          ...createNumericControlMetadata().controls[0],
-          concept: {
-            ...createNumericControlMetadata().controls[0].concept,
-            description: 'Note: Use &lt;10mg &amp; monitor &gt; 60bpm',
-          },
-        }],
-      });
-
-      renderContainer({ metadata });
-      expect(screen.getByRole('spinbutton')).toBeInTheDocument();
-    });
-
-    it('should decode HTML entities in control properties URL', () => {
-      const metadata = createNumericControlMetadata({
-        controls: [{
-          ...createNumericControlMetadata().controls[0],
-          properties: {
-            ...createNumericControlMetadata().controls[0].properties,
-            url: '/provider?attrName=type&amp;attrValue=Doctor',
-          },
-        }],
-      });
-
-      renderContainer({ metadata });
-      expect(screen.getByRole('spinbutton')).toBeInTheDocument();
-    });
-
-    it('should decode HTML entities in onFormInit script', async () => {
-      const metadata = createNumericControlMetadata({
-        events: {
-          onFormInit: utf8ToBase64("function(form){form.get('Pulse').setEnabled(false);}"),
-        },
-      });
-
-      renderContainer({ metadata });
-
-      await waitFor(() => {
-        const input = screen.getByRole('spinbutton');
-        expect(input).toBeDisabled();
-      });
-    });
   });
 
   describe('Coverage Improvements', () => {

--- a/test/components/Container.test.js
+++ b/test/components/Container.test.js
@@ -885,5 +885,65 @@ describe('Container', () => {
         containerRef.current.onEventTrigger('some-path', 'onValueChange');
       }).not.toThrow();
     });
+
+    it('should rebuild control tree when metadata prop changes', () => {
+      const initialMetadata = createNumericControlMetadata({
+        controls: [{
+          ...createNumericControlMetadata().controls[0],
+          label: { type: 'label', value: 'Initial Pulse Label' },
+        }],
+      });
+
+      const updatedMetadata = createNumericControlMetadata({
+        controls: [{
+          ...createNumericControlMetadata().controls[0],
+          label: { type: 'label', value: 'Updated Pulse Label' },
+        }],
+      });
+
+      const containerRef = React.createRef();
+      const { rerender } = render(
+        <Container ref={containerRef} {...defaultProps} metadata={initialMetadata} />,
+      );
+
+      expect(screen.getByText(/Initial Pulse Label/)).toBeInTheDocument();
+      expect(containerRef.current).toBeTruthy();
+      const initialTreeData = containerRef.current.state.data;
+
+      rerender(
+        <Container ref={containerRef} {...defaultProps} metadata={updatedMetadata} />,
+      );
+
+      expect(screen.getByText(/Updated Pulse Label/)).toBeInTheDocument();
+      const updatedTreeData = containerRef.current.state.data;
+
+      expect(initialTreeData).not.toBe(updatedTreeData);
+    });
+
+    it('should decode HTML entities in metadata when updated', () => {
+      const initialMetadata = createNumericControlMetadata({
+        controls: [{
+          ...createNumericControlMetadata().controls[0],
+          label: { type: 'label', value: 'Pulse &gt; 60' },
+        }],
+      });
+
+      const updatedMetadata = createNumericControlMetadata({
+        controls: [{
+          ...createNumericControlMetadata().controls[0],
+          label: { type: 'label', value: 'Blood Pressure &amp; Temperature' },
+        }],
+      });
+
+      const { rerender } = renderContainer({ metadata: initialMetadata });
+
+      expect(screen.getByText(/Pulse > 60/)).toBeInTheDocument();
+
+      rerender(
+        <Container {...defaultProps} metadata={updatedMetadata} />,
+      );
+
+      expect(screen.getByText(/Blood Pressure & Temperature/)).toBeInTheDocument();
+    });
   });
 });

--- a/test/helpers/encodingUtils.test.js
+++ b/test/helpers/encodingUtils.test.js
@@ -41,12 +41,6 @@ describe('encodingUtils', () => {
             expect(unescapeHtml(null)).toBe(null);
             expect(unescapeHtml(undefined)).toBe(undefined);
         });
-
-        it('should fully decode multiple levels of HTML encoding', () => {
-            expect(unescapeHtml('&amp;amp;amp;amp;attrName')).toBe('&attrName');
-            expect(unescapeHtml('&amp;amp;')).toBe('&');
-            expect(unescapeHtml('url?a=1&amp;amp;b=2')).toBe('url?a=1&b=2');
-        });
     });
 
     describe('deepUnescapeStrings', () => {

--- a/test/helpers/encodingUtils.test.js
+++ b/test/helpers/encodingUtils.test.js
@@ -1,0 +1,139 @@
+import {
+    unescapeHtml,
+    deepUnescapeStrings,
+    utf8ToBase64,
+    base64ToUtf8,
+} from 'src/helpers/encodingUtils';
+
+describe('encodingUtils', () => {
+    describe('unescapeHtml', () => {
+        it('should unescape &lt; to <', () => {
+            expect(unescapeHtml('a &lt; b')).toBe('a < b');
+        });
+
+        it('should unescape &gt; to >', () => {
+            expect(unescapeHtml('a &gt; b')).toBe('a > b');
+        });
+
+        it('should unescape &amp; to &', () => {
+            expect(unescapeHtml('a &amp; b')).toBe('a & b');
+        });
+
+        it('should unescape multiple entities in a single string', () => {
+            expect(unescapeHtml('if (a &lt; b &amp;&amp; c &gt; d)'))
+                .toBe('if (a < b && c > d)');
+        });
+
+        it('should unescape &quot; to "', () => {
+            expect(unescapeHtml('a &quot;quoted&quot; b')).toBe('a "quoted" b');
+        });
+
+        it('should unescape &#39; to \'', () => {
+            expect(unescapeHtml('it&#39;s')).toBe("it's");
+        });
+
+        it('should return the same string when no entities are present', () => {
+            expect(unescapeHtml('hello world')).toBe('hello world');
+        });
+
+        it('should return non-string values as-is', () => {
+            expect(unescapeHtml(42)).toBe(42);
+            expect(unescapeHtml(null)).toBe(null);
+            expect(unescapeHtml(undefined)).toBe(undefined);
+        });
+    });
+
+    describe('deepUnescapeStrings', () => {
+        it('should unescape a plain string', () => {
+            expect(deepUnescapeStrings('a &lt; b')).toBe('a < b');
+        });
+
+        it('should unescape all string values in an object', () => {
+            const input = { name: 'BP &gt; 60', units: 'mmHg' };
+            const result = deepUnescapeStrings(input);
+            expect(result.name).toBe('BP > 60');
+            expect(result.units).toBe('mmHg');
+        });
+
+        it('should unescape strings in nested objects', () => {
+            const input = {
+                label: { value: 'Bone Transfer Free &amp; Vascularised' },
+                events: { onFormInit: 'if (x &gt; 0) {}' },
+            };
+            const result = deepUnescapeStrings(input);
+            expect(result.label.value).toBe('Bone Transfer Free & Vascularised');
+            expect(result.events.onFormInit).toBe('if (x > 0) {}');
+        });
+
+        it('should unescape strings inside arrays', () => {
+            expect(deepUnescapeStrings(['a &lt; b', 'c &gt; d']))
+                .toEqual(['a < b', 'c > d']);
+        });
+
+        it('should handle arrays of objects', () => {
+            const input = [{ name: 'Option &amp; Value' }, { name: 'Plain' }];
+            const result = deepUnescapeStrings(input);
+            expect(result[0].name).toBe('Option & Value');
+            expect(result[1].name).toBe('Plain');
+        });
+
+        it('should return numbers as-is', () => {
+            expect(deepUnescapeStrings(42)).toBe(42);
+        });
+
+        it('should return null as-is', () => {
+            expect(deepUnescapeStrings(null)).toBe(null);
+        });
+
+        it('should return boolean as-is', () => {
+            expect(deepUnescapeStrings(true)).toBe(true);
+        });
+
+        it('should handle a full form metadata structure', () => {
+            const metadata = {
+                name: 'Vitals',
+                controls: [
+                    { id: '1', type: 'label', label: { value: 'BP &gt; 60' } },
+                ],
+                events: {
+                    onFormInit: 'if (a &lt; b &amp;&amp; c &gt; d) { return; }',
+                },
+            };
+            const result = deepUnescapeStrings(metadata);
+            expect(result.controls[0].label.value).toBe('BP > 60');
+            expect(result.events.onFormInit).toBe('if (a < b && c > d) { return; }');
+            expect(result.name).toBe('Vitals');
+        });
+
+        it('should handle URL with & in control properties', () => {
+            const input = {
+                properties: {
+                    url: 'openmrs/ws/rest/v1/provider?v=custom&amp;attrName=type',
+                },
+            };
+            const result = deepUnescapeStrings(input);
+            expect(result.properties.url)
+                .toBe('openmrs/ws/rest/v1/provider?v=custom&attrName=type');
+        });
+    });
+
+    describe('base64ToUtf8', () => {
+        it('should return empty string for undefined', () => {
+            expect(base64ToUtf8(undefined)).toBe('');
+        });
+
+        it('should return empty string for null', () => {
+            expect(base64ToUtf8(null)).toBe('');
+        });
+
+        it('should return empty string for empty string', () => {
+            expect(base64ToUtf8('')).toBe('');
+        });
+
+        it('should decode a valid base64 string', () => {
+            const original = 'function(ctx) { return ctx; }';
+            const encoded = utf8ToBase64(original);
+            expect(base64ToUtf8(encoded)).toBe(original);
+        });
+    });
+});

--- a/test/helpers/encodingUtils.test.js
+++ b/test/helpers/encodingUtils.test.js
@@ -41,6 +41,12 @@ describe('encodingUtils', () => {
             expect(unescapeHtml(null)).toBe(null);
             expect(unescapeHtml(undefined)).toBe(undefined);
         });
+
+        it('should fully decode multiple levels of HTML encoding', () => {
+            expect(unescapeHtml('&amp;amp;amp;amp;attrName')).toBe('&attrName');
+            expect(unescapeHtml('&amp;amp;')).toBe('&');
+            expect(unescapeHtml('url?a=1&amp;amp;b=2')).toBe('url?a=1&b=2');
+        });
     });
 
     describe('deepUnescapeStrings', () => {


### PR DESCRIPTION
Form metadata containing HTML-escaped entities (&gt;, &lt;, &amp;) were displaying as literal escaped text instead of rendering as actual characters (>, <, &).

Root Cause:
Form metadata from the API arrives HTML-escaped but was not being unescaped before rendering in form2-controls components (labels, obsgroup etc)

Solution:
1. Added encodingUtils.js with deepUnescapeStrings() - recursively unescapes all string values in objects using html-entities library
2. Updated Container.jsx:
  - Constructor: this.metadata = deepUnescapeStrings(this.props.metadata) - unescapes all metadata on mount
  - Render: const formTranslations = deepUnescapeStrings(rawTranslations) - unescapes form translations
   
Labels display correctly: "Blood Pressure > 60" renders as > not &gt;
ObsGroups display correctly with HTML characters
Existing forms without HTML characters unaffected
