### PR TITLE
BAH-4764 | Increase combo/dropdown min-width to prevent premature text truncation

### DIFF
--- a/styles/bahmniAppsFormBuilder/_form.scss
+++ b/styles/bahmniAppsFormBuilder/_form.scss
@@ -232,7 +232,7 @@ $lightestGray: #eee;
           .cds--list-box:not(.cds--multi-select) {
             flex: 0 0 auto;
             width: auto;
-            min-width: calc(#{$spacing-13} * 2);
+            min-width: $spacing-13;
             max-width: calc(
               #{$spacing-13} * 3 + #{$spacing-12} + #{$spacing-06}
             );

--- a/styles/bahmniAppsFormBuilder/_form.scss
+++ b/styles/bahmniAppsFormBuilder/_form.scss
@@ -232,7 +232,7 @@ $lightestGray: #eee;
           .cds--list-box:not(.cds--multi-select) {
             flex: 0 0 auto;
             width: auto;
-            min-width: $spacing-13;
+            min-width: calc(#{$spacing-13} * 2);
             max-width: calc(
               #{$spacing-13} * 3 + #{$spacing-12} + #{$spacing-06}
             );

--- a/styles/common/_autoComplete.scss
+++ b/styles/common/_autoComplete.scss
@@ -1,17 +1,3 @@
-/**
- * Carbon ComboBox: truncate selected text with ellipsis before the clear (✕)
- * and chevron (▾) buttons. Setting max-width (not just padding) so the content
- * box is genuinely smaller — that's what triggers text-overflow: ellipsis.
- * Clear button ~2rem + chevron ~2.5rem = ~4.5rem reserved on the right.
- */
-.cds--combo-box .cds--list-box__field .cds--text-input {
-  max-width: calc(100% - 4.5rem) !important;
-  min-width: 0 !important;
-  overflow: hidden !important;
-  text-overflow: ellipsis !important;
-  white-space: nowrap !important;
-}
-
 .Select {
   position: relative;
 }


### PR DESCRIPTION
## Summary

- Increases `min-width` on `.cds--combo-box`, `.cds--dropdown`, and `.cds--list-box` from `$spacing-13` (10rem / 160px) to `calc(#{$spacing-13} * 2)` (20rem / 320px)
- Fixes premature ellipsis truncation for typical medical term values (e.g. "Abdominal pain") that fit within the dropdown but were being cut off due to insufficient minimum width
