### PR TITLE
BAH-4813 | Fix section add-more, clone alignment, and drop shadow

### DIFF
--- a/src/components/bahmni-design-system/Section.jsx
+++ b/src/components/bahmni-design-system/Section.jsx
@@ -5,7 +5,9 @@ import classNames from 'classnames';
 import { IntlProvider, injectIntl } from 'react-intl';
 import addMoreDecorator from 'components/AddMoreDecorator';
 import { getGroupedControls, displayRowControls } from 'src/helpers/controlsParser';
-import { Accordion, AccordionItem } from '@bahmni/design-system';
+import { Accordion, AccordionItem, IconButton, Button } from '@bahmni/design-system';
+import { Add, Close } from '@carbon/icons-react';
+import find from 'lodash/find';
 
 export class Section extends addMoreDecorator(Component) {
 
@@ -82,23 +84,52 @@ export class Section extends addMoreDecorator(Component) {
       id: label.translationKey || 'defaultId',
     });
 
+    const { properties } = this.props.metadata;
+    const isAddMoreEnabled = find(properties, (value, key) => (key === 'addMore' && value));
+
     return (
-      <div className={classNames('form-builder-fieldset', { hidden: this.props.hidden })}>
-        {this.showAddMore()}
-        <Accordion align="start">
-          <AccordionItem
-            open={!this.state.collapse}
-            onHeadingClick={this._onCollapse}
-            title={title}
-          >
-            <IntlProvider {...this.props.intl}>
-              <div className={`obsGroup-controls${disableClass}`}>
-                {displayRowControls(groupedRowControls, this.props.children.toArray(), childProps)}
+      <React.Fragment>
+        <div className={classNames('form-builder-fieldset', { hidden: this.props.hidden })}>
+          <div className="obs-group-add-more-wrapper">
+            {isAddMoreEnabled && this.props.showRemove && (
+              <div className="obs-group-remove-btn">
+                <IconButton
+                  label="Remove"
+                  kind="ghost"
+                  size="sm"
+                  onClick={this.onRemoveControl}
+                >
+                  <Close />
+                </IconButton>
               </div>
-            </IntlProvider>
-          </AccordionItem>
-        </Accordion>
-      </div>
+            )}
+            <Accordion align="start">
+              <AccordionItem
+                open={!this.state.collapse}
+                onHeadingClick={this._onCollapse}
+                title={title}
+              >
+                <IntlProvider {...this.props.intl}>
+                  <div className={`obsGroup-controls${disableClass}`}>
+                    {displayRowControls(groupedRowControls, this.props.children.toArray(), childProps)}
+                  </div>
+                </IntlProvider>
+              </AccordionItem>
+            </Accordion>
+          </div>
+        </div>
+        {isAddMoreEnabled && this.props.showAddMore && (
+          <Button
+            kind="tertiary"
+            size="sm"
+            renderIcon={Add}
+            onClick={this.onAddControl}
+            className="obs-group-add-btn"
+          >
+            Add more
+          </Button>
+        )}
+      </React.Fragment>
     );
   }
 }

--- a/styles/bahmniAppsFormBuilder/_form.scss
+++ b/styles/bahmniAppsFormBuilder/_form.scss
@@ -89,17 +89,13 @@ $lightestGray: #eee;
           flex-wrap: wrap;
           position: relative;
 
-          // Default: clone stays in the flex flow (for text, numeric, image, video etc.)
+          // Clone: consistently positioned at the right, to the left of "Add note",
+          // for all control types (dropdowns, text, numeric, tags, etc.).
           .form-builder-clone {
             float: none;
             display: inline-flex;
             align-items: center;
             gap: $spacing-03;
-            align-self: center;
-          }
-
-          // Coded/select controls: absolutely position clone to the left of "Add note".
-          &:has(.obs-control-select-wrapper) .form-builder-clone {
             position: absolute;
             right: $spacing-12;
             top: $spacing-03;
@@ -107,22 +103,11 @@ $lightestGray: #eee;
           }
 
           // TextBox (text type) renders inside obs-comment-section-wrap > cds--text-area__wrapper.
-          // Shrink the wrapper so the clone fits on the same row, pinned top-right.
-          // Clone is two sm icon buttons (2rem each) + gap (0.5rem) = ~4.5rem wide, so we
-          // need at least 5rem of clearance from the content-box right edge.
           &:has(.obs-comment-section-wrap .cds--text-area__wrapper)
             > .obs-comment-section-wrap {
             flex: 1 1 auto;
             max-width: calc(100% - #{$spacing-11});
             margin-top: 0;
-          }
-
-          &:has(.obs-comment-section-wrap .cds--text-area__wrapper)
-            .form-builder-clone {
-            position: absolute;
-            right: $spacing-12;
-            top: $spacing-03;
-            z-index: 1;
           }
 
           .form-builder-comment-wrap {
@@ -330,13 +315,6 @@ $lightestGray: #eee;
             pointer-events: auto;
           }
 
-          // Selectable-tag controls: absolutely position clone to the left of "Add note".
-          &:has(.cds--tag--selectable) .form-builder-clone {
-            position: absolute;
-            right: $spacing-12;
-            top: $spacing-03;
-            z-index: 1;
-          }
 
           // Selectable-tag wrapper: allow tags to wrap naturally.
           > div:has(.cds--tag--selectable) {
@@ -659,11 +637,12 @@ $lightestGray: #eee;
       }
 
       div.form-builder-fieldset {
-        border: 1px solid carbon-theme.$border-subtle-01;
+        border: none;
       }
 
       .form-builder-fieldset {
-        border-top: 1px solid #c0c0c0;
+        border: none;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.08);
         margin: 15px 3px 3px;
         box-sizing: border-box;
         border-radius: 5px;
@@ -673,18 +652,8 @@ $lightestGray: #eee;
           z-index: 1;
         }
 
-        // Section-level add-more: align with the right edge of the first field
-        // and vertically centred with its row (accordion header ~48px + field offset).
-        > .form-builder-clone {
-          position: absolute;
-          right: $spacing-07;
-          top: calc(#{$spacing-09} + #{$spacing-07});
-          transform: translateY(-50%);
-          z-index: 1;
-          display: inline-flex;
-          align-items: center;
-          gap: $spacing-03;
-        }
+        // Section now uses "Add more" button below the fieldset (same as ObsGroupControl),
+        // so no absolute clone positioning needed here.
 
         // Exact chain prevents nested obs-group accordions from inheriting these resets.
         > .obs-group-add-more-wrapper > .cds--accordion {

--- a/test/components/bahmni-design-system/Section.test.js
+++ b/test/components/bahmni-design-system/Section.test.js
@@ -143,7 +143,7 @@ describe('Carbon Section', () => {
     ComponentStore.deRegisterComponent('numeric');
   });
 
-  it('should render AddMore control above accordion header when addMore is enabled', () => {
+  it('should render Add more button below fieldset and remove button inside when addMore is enabled', () => {
     const addMoreMetadata = {
       ...metadata,
       properties: { ...metadata.properties, addMore: true },
@@ -154,13 +154,15 @@ describe('Carbon Section', () => {
         {...defaultProps}
         metadata={addMoreMetadata}
         showAddMore
-        showRemove={false}
+        showRemove
       />
     );
 
+    expect(screen.getByText('Add more')).toBeInTheDocument();
+    expect(screen.getByLabelText('Remove')).toBeInTheDocument();
     const fieldset = document.querySelector('.form-builder-fieldset');
-    expect(fieldset.firstChild).toHaveClass('form-builder-clone');
-    expect(fieldset.children[1]).toHaveClass('cds--accordion');
+    expect(fieldset.querySelector('.obs-group-add-more-wrapper')).toBeInTheDocument();
+    expect(fieldset.querySelector('.obs-group-remove-btn')).toBeInTheDocument();
   });
 
   it('should pass prop collapse value to children regardless of internal toggle state', () => {


### PR DESCRIPTION
## Description
- Section uses "Add more +" button below the fieldset (same pattern as ObsGroupControl) with × remove button at top-right inside accordion wrapper
- All obs clone (+/×) buttons consistently absolute-positioned for uniform alignment across all control types (dropdowns, text, numeric, tags)
- Replace fieldset border with drop shadow for sections and obs-groups
- Add margin-left to "Add more" button for section border alignment