### PR TITLE
BAH-4831 | Add. baseOn reference to each Observation entry if a form has basedOn reference

### DIFF
--- a/src/helpers/FhirObservationTransformer.js
+++ b/src/helpers/FhirObservationTransformer.js
@@ -211,6 +211,7 @@ const createObservationResource = (observationPayload, options) => {
  * @param {Object} options.patientReference - FHIR Reference to patient (e.g., { reference: 'Patient/uuid' })
  * @param {Object} options.encounterReference - FHIR Reference to encounter (e.g., { reference: 'Encounter/uuid' })
  * @param {Object} options.performerReference - FHIR Reference to performer (e.g., { reference: 'Practitioner/uuid' })
+ * @param {Object} [options.basedOnReference] - Optional FHIR Reference for basedOn (e.g., { reference: 'ServiceRequest/uuid' })
  * @returns {Array<{resource: Object, fullUrl: string}>} Array of FHIR Observation bundle entries
  */
 export function getFhirObservations(observations, options) {

--- a/src/helpers/FhirObservationTransformer.js
+++ b/src/helpers/FhirObservationTransformer.js
@@ -223,6 +223,8 @@ export function getFhirObservations(observations, options) {
     return [];
   }
 
+  const basedOn = options.basedOnReference ? [options.basedOnReference] : undefined;
+
   const results = [];
 
   for (const obs of observations) {
@@ -259,6 +261,7 @@ export function getFhirObservations(observations, options) {
         resource: {
           ...parentObservation,
           id: parentUuid,
+          basedOn,
         },
         fullUrl: parentFullUrl,
       });
@@ -271,6 +274,7 @@ export function getFhirObservations(observations, options) {
         resource: {
           ...observation,
           id: uuid,
+          basedOn,
         },
         fullUrl,
       });

--- a/test/helpers/FhirObservationTransformer.test.js
+++ b/test/helpers/FhirObservationTransformer.test.js
@@ -15,7 +15,7 @@ describe('FhirObservationTransformer', () => {
     performerReference: { reference: 'Practitioner/practitioner-uuid' },
   };
 
-  describe('toFhir', () => {
+  describe('getFhirObservations', () => {
     it('should return empty array for null observations', () => {
       const result = getFhirObservations(null, defaultOptions);
       expect(result).toEqual([]);
@@ -337,6 +337,25 @@ describe('FhirObservationTransformer', () => {
       const result = getFhirObservations(observations, defaultOptions);
 
       expect(result[0].resource.valueString).toBeUndefined();
+    });
+
+    it('should handle basedOnReference when provided', () => {
+      const basedOnReference = { reference: 'ServiceRequest/sr-uuid' };
+      const optionsWithBasedOn = {
+        ...defaultOptions,
+        basedOnReference,
+      };
+
+      const observations = [
+        {
+          concept: { uuid: 'concept-uuid' },
+          value: 'test',
+        },
+      ];
+
+      const result = getFhirObservations(observations, optionsWithBasedOn);
+
+      expect(result[0].resource.basedOn).toEqual([basedOnReference]);
     });
   });
 


### PR DESCRIPTION
Accept the basedOnReference in options for getFhirObservations method, so that basedOn reference can be added to all observations in a form .